### PR TITLE
chore: bump to 0.1.4 (resume work + npm badges)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,31 @@ section is also used as the body of the Release notes by the
 
 ## [Unreleased]
 
+## [0.1.4] - 2026-05-02
+
+### Added
+- Auto-resume on bare `claudely` invocation: when a saved claude session
+  exists for the current directory, `claudely` (with no args) now resumes
+  it instead of starting fresh. A one-line stderr notice announces the
+  behavior (`claudely: resuming previous session (use --new for a fresh
+  one)`).
+- New `--new` flag forces a fresh session even when a saved one exists
+  for the cwd.
+- New `CLAUDELY_NO_AUTO_RESUME=1` env var disables auto-resume globally.
+
+### Changed
+- Explicit resume flags (`-c` / `--continue`, `-r` / `--resume`,
+  `--session-id`, `--from-pr`) now skip the model picker. Previously the
+  picker still ran even when the user was clearly resuming, producing a
+  model value the saved session would override.
+- Model selection and resume detection are now independent decisions.
+  `claudely --model X` (with a saved session) auto-resumes AND passes
+  `--model X` through to claude; `claudely -c --model X` no longer
+  silently drops the explicit model. Env-derived model defaults
+  (`CLAUDELY_MODEL`, provider-specific env vars) are skipped on resume,
+  since they're "default for fresh," not "intent to override the saved
+  session."
+
 ## [0.1.3] - 2026-05-01
 
 ### Added
@@ -65,7 +90,8 @@ section is also used as the body of the Release notes by the
   `--` separator.
 - CI workflow (Node 20, 22) and npm publish workflow triggered by GitHub Release.
 
-[Unreleased]: https://github.com/mforce/claudely/compare/v0.1.3...HEAD
+[Unreleased]: https://github.com/mforce/claudely/compare/v0.1.4...HEAD
+[0.1.4]: https://github.com/mforce/claudely/compare/v0.1.3...v0.1.4
 [0.1.3]: https://github.com/mforce/claudely/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/mforce/claudely/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/mforce/claudely/compare/v0.1.0...v0.1.1

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # claudely
 
+[![npm version](https://img.shields.io/npm/v/claudely.svg)](https://www.npmjs.com/package/claudely)
+[![npm downloads](https://img.shields.io/npm/dm/claudely.svg)](https://www.npmjs.com/package/claudely)
+[![license: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+
 *pron. **"CLAW-dlee"** — Claude, locally.*
 
 Launch [Claude Code](https://docs.anthropic.com/en/docs/claude-code) against a
@@ -33,6 +37,8 @@ environment variables for the local path and spawns `claude` unchanged.
 
 ## Install
 
+Published on npm as [`claudely`](https://www.npmjs.com/package/claudely).
+
 ```bash
 # global (recommended)
 npm i -g claudely
@@ -41,7 +47,9 @@ npm i -g claudely
 npx claudely
 ```
 
-Requires Node.js ≥ 20 and the `claude` CLI on your `PATH`.
+Requires Node.js ≥ 20 and the `claude` CLI on your `PATH`. (npm 7+ will
+install Claude Code automatically as a peer dependency; users who got
+`claude` via the native installer or Homebrew are unaffected.)
 
 ## Quickstart
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claudely",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claudely",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "^7.2.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claudely",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Claude, locally. Launch Claude Code against a local LLM (LM Studio, Ollama, llama.cpp, or any Anthropic-compatible endpoint). Unaffiliated community helper.",
   "license": "MIT",
   "author": "mforce",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -25,11 +25,16 @@ import {
 import { applyCompat, loadSettings } from "./compat.js";
 import { splitArgs, type FlagSpec } from "./argsplit.js";
 import { renderVersion } from "./version.js";
-import { isResumeIntent, assembleClaudeArgv } from "./resume.js";
+import {
+  isResumeIntent,
+  assembleClaudeArgv,
+  hasRecentSessionForCwd,
+  shouldAutoResume,
+} from "./resume.js";
 
 const FLAG_SPEC: FlagSpec = {
   string: new Set(["provider", "model", "base-url", "token"]),
-  boolean: new Set(["list", "help", "version"]),
+  boolean: new Set(["list", "help", "version", "new"]),
   short: {
     p: "provider",
     m: "model",
@@ -48,8 +53,14 @@ claudely options:
   -u, --base-url <url>    Override the provider's default base URL
   -t, --token <token>     Override the provider's default auth token
       --list              Print available models for the provider and exit
+      --new               Force a fresh session (skip auto-resume)
   -h, --help              Show this help
   -V, --version           Print claudely and claude versions, then exit
+
+Bare \`claudely\` (no args, no --model) auto-resumes the most recent
+claude session for the current directory when one exists. Use --new to
+force a fresh session, or set CLAUDELY_NO_AUTO_RESUME=1 to disable
+auto-resume globally.
 
 When you pass a claude resume flag (-c/--continue, -r/--resume,
 --session-id, --from-pr) claudely skips the model picker and does NOT
@@ -108,6 +119,7 @@ async function main(): Promise<number> {
         "base-url": { type: "string", short: "u" },
         token: { type: "string", short: "t" },
         list: { type: "boolean" },
+        new: { type: "boolean" },
         help: { type: "boolean", short: "h" },
         version: { type: "boolean", short: "V" },
       },
@@ -165,6 +177,21 @@ async function main(): Promise<number> {
       process.stdout.write(cols.join("\t") + "\n");
     }
     return 0;
+  }
+
+  // Auto-resume on bare invocation: if the user typed `claudely` with no
+  // forwarded args and there's a saved session for this cwd, behave as if
+  // they had typed `claudely --continue`. --new and CLAUDELY_NO_AUTO_RESUME
+  // opt out.
+  const autoResume = shouldAutoResume({
+    ownValues: values,
+    claudeArgs,
+    hasRecentSession: hasRecentSessionForCwd(process.cwd()),
+    env: process.env,
+  });
+  if (autoResume) {
+    process.stderr.write("claudely: resuming previous session (use --new for a fresh one)\n");
+    claudeArgs.push("--continue");
   }
 
   // When resuming a saved session, the model is already encoded in that

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -194,15 +194,18 @@ async function main(): Promise<number> {
     claudeArgs.push("--continue");
   }
 
-  // When resuming a saved session, the model is already encoded in that
-  // session — running the picker would just produce a value that gets
-  // overridden, and re-injecting `--model` can fight the saved state.
+  // Resume vs. model selection are independent decisions:
+  //   - Resume controls whether the picker runs and whether --continue is added.
+  //   - Model selection controls what (if anything) goes into --model.
+  // On resume, an explicit CLI --model is still honored (claude supports
+  // --continue --model X to switch models on a resumed conversation), but
+  // env-derived model defaults are skipped — they're "default for fresh",
+  // not "intent to override the saved session".
   const resuming = isResumeIntent(claudeArgs);
 
-  let model: string | undefined;
-  if (!resuming) {
+  let model: string | undefined = values.model;
+  if (!model && !resuming) {
     model =
-      values.model ??
       process.env.CLAUDELY_MODEL ??
       (provider.modelEnvVar ? process.env[provider.modelEnvVar] : undefined);
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -25,6 +25,7 @@ import {
 import { applyCompat, loadSettings } from "./compat.js";
 import { splitArgs, type FlagSpec } from "./argsplit.js";
 import { renderVersion } from "./version.js";
+import { isResumeIntent, assembleClaudeArgv } from "./resume.js";
 
 const FLAG_SPEC: FlagSpec = {
   string: new Set(["provider", "model", "base-url", "token"]),
@@ -49,6 +50,10 @@ claudely options:
       --list              Print available models for the provider and exit
   -h, --help              Show this help
   -V, --version           Print claudely and claude versions, then exit
+
+When you pass a claude resume flag (-c/--continue, -r/--resume,
+--session-id, --from-pr) claudely skips the model picker and does NOT
+inject --model — the saved session already knows its model.
 
 Any flag claudely does not recognize is forwarded verbatim to \`claude\`.
 Use \`--\` as an escape hatch to force a token through (e.g. when claude
@@ -162,41 +167,49 @@ async function main(): Promise<number> {
     return 0;
   }
 
-  let model =
-    values.model ??
-    process.env.CLAUDELY_MODEL ??
-    (provider.modelEnvVar ? process.env[provider.modelEnvVar] : undefined);
+  // When resuming a saved session, the model is already encoded in that
+  // session — running the picker would just produce a value that gets
+  // overridden, and re-injecting `--model` can fight the saved state.
+  const resuming = isResumeIntent(claudeArgs);
 
-  if (!model) {
-    const entries = await listForProvider(provider, baseUrl, token);
-    if (entries.length === 0) {
-      console.error(
-        `claudely: no models discovered for provider '${providerName}' at ${baseUrl}.`,
-      );
-      if (provider.startHint) console.error(`  hint: ${provider.startHint}`);
-      return 1;
+  let model: string | undefined;
+  if (!resuming) {
+    model =
+      values.model ??
+      process.env.CLAUDELY_MODEL ??
+      (provider.modelEnvVar ? process.env[provider.modelEnvVar] : undefined);
+
+    if (!model) {
+      const entries = await listForProvider(provider, baseUrl, token);
+      if (entries.length === 0) {
+        console.error(
+          `claudely: no models discovered for provider '${providerName}' at ${baseUrl}.`,
+        );
+        if (provider.startHint) console.error(`  hint: ${provider.startHint}`);
+        return 1;
+      }
+      model = await search<string>({
+        message: `${providerName} model`,
+        source: async (input) => {
+          const q = (input ?? "").toLowerCase();
+          const filtered = !q
+            ? entries
+            : entries.filter(
+                (e) =>
+                  e.display.toLowerCase().includes(q) ||
+                  e.id.toLowerCase().includes(q),
+              );
+          return filtered.map((e) => ({
+            name: e.display,
+            value: e.id,
+            description:
+              e.extras.length > 0
+                ? `${e.id}  ·  ${e.extras.join(" · ")}`
+                : e.id,
+          }));
+        },
+      });
     }
-    model = await search<string>({
-      message: `${providerName} model`,
-      source: async (input) => {
-        const q = (input ?? "").toLowerCase();
-        const filtered = !q
-          ? entries
-          : entries.filter(
-              (e) =>
-                e.display.toLowerCase().includes(q) ||
-                e.id.toLowerCase().includes(q),
-            );
-        return filtered.map((e) => ({
-          name: e.display,
-          value: e.id,
-          description:
-            e.extras.length > 0
-              ? `${e.id}  ·  ${e.extras.join(" · ")}`
-              : e.id,
-        }));
-      },
-    });
   }
 
   // Build the env recipe to hand to claude.
@@ -220,12 +233,14 @@ async function main(): Promise<number> {
   const compat = applyCompat({ settings, baseUrl, existingClaudeArgs: claudeArgs });
   for (const w of compat.warnings) process.stderr.write(`claudely: ${w}\n`);
 
+  const claudeArgv = assembleClaudeArgv({
+    model,
+    extraArgs: compat.extraArgs,
+    claudeArgs,
+  });
+
   return await new Promise<number>((resolve) => {
-    const child = spawn(
-      "claude",
-      ["--model", model!, ...compat.extraArgs, ...claudeArgs],
-      { stdio: "inherit", env },
-    );
+    const child = spawn("claude", claudeArgv, { stdio: "inherit", env });
     child.on("error", (err) => {
       console.error(`claudely: failed to spawn claude: ${err.message}`);
       resolve(127);

--- a/src/resume.test.ts
+++ b/src/resume.test.ts
@@ -95,6 +95,24 @@ test("assembleClaudeArgv: model undefined (resume case) → no --model in argv",
   assert.equal(out.includes("--model"), false);
 });
 
+test("assembleClaudeArgv: explicit model + --continue in claudeArgs → both present (resume + model override)", () => {
+  const out = assembleClaudeArgv({
+    model: "qwen3-coder",
+    extraArgs: [],
+    claudeArgs: ["--continue"],
+  });
+  assert.deepEqual(out, ["--model", "qwen3-coder", "--continue"]);
+});
+
+test("assembleClaudeArgv: explicit model + -c short form → both present", () => {
+  const out = assembleClaudeArgv({
+    model: "qwen3-coder",
+    extraArgs: ["--effort", "high"],
+    claudeArgs: ["-c"],
+  });
+  assert.deepEqual(out, ["--model", "qwen3-coder", "--effort", "high", "-c"]);
+});
+
 test("assembleClaudeArgv: empty extras and claude args → just the model pair (or nothing)", () => {
   assert.deepEqual(
     assembleClaudeArgv({ model: "m", extraArgs: [], claudeArgs: [] }),
@@ -184,8 +202,8 @@ test("shouldAutoResume: --list path → false", () => {
   assert.equal(shouldAutoResume({ ...baseInputs, ownValues: { list: true } }), false);
 });
 
-test("shouldAutoResume: --model present (CLI or env collapsed) → false", () => {
-  assert.equal(shouldAutoResume({ ...baseInputs, ownValues: { model: "x" } }), false);
+test("shouldAutoResume: --model present does NOT block auto-resume — model and resume are independent", () => {
+  assert.equal(shouldAutoResume({ ...baseInputs, ownValues: { model: "x" } }), true);
 });
 
 test("shouldAutoResume: any forwarded claudeArgs (positional or flag) → false", () => {

--- a/src/resume.test.ts
+++ b/src/resume.test.ts
@@ -1,6 +1,15 @@
-import { test } from "node:test";
+import { test, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
-import { isResumeIntent, assembleClaudeArgv } from "./resume.js";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  isResumeIntent,
+  assembleClaudeArgv,
+  encodeCwdForClaude,
+  hasRecentSessionForCwd,
+  shouldAutoResume,
+} from "./resume.js";
 
 test("isResumeIntent: empty args → false", () => {
   assert.equal(isResumeIntent([]), false);
@@ -95,4 +104,108 @@ test("assembleClaudeArgv: empty extras and claude args → just the model pair (
     assembleClaudeArgv({ model: undefined, extraArgs: [], claudeArgs: [] }),
     [],
   );
+});
+
+test("encodeCwdForClaude mirrors claude's per-cwd directory naming", () => {
+  assert.equal(encodeCwdForClaude("/home/cesar/dev/claudely"), "-home-cesar-dev-claudely");
+  assert.equal(
+    encodeCwdForClaude("/home/cesar/dev/shelfydex--worktrees/feat-api-security"),
+    "-home-cesar-dev-shelfydex--worktrees-feat-api-security",
+  );
+});
+
+let fakeHome: string;
+
+beforeEach(() => {
+  fakeHome = mkdtempSync(join(tmpdir(), "claudely-home-"));
+});
+
+afterEach(() => {
+  rmSync(fakeHome, { recursive: true, force: true });
+});
+
+function seedSessionFile(cwd: string, sessionId: string) {
+  const dir = join(fakeHome, ".claude", "projects", encodeCwdForClaude(cwd));
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, `${sessionId}.jsonl`), '{"type":"summary"}\n');
+}
+
+test("hasRecentSessionForCwd: no projects dir at all → false", () => {
+  assert.equal(hasRecentSessionForCwd("/some/where", { home: fakeHome }), false);
+});
+
+test("hasRecentSessionForCwd: empty per-cwd dir (no .jsonl) → false", () => {
+  const cwd = "/home/u/proj";
+  mkdirSync(join(fakeHome, ".claude", "projects", encodeCwdForClaude(cwd)), {
+    recursive: true,
+  });
+  assert.equal(hasRecentSessionForCwd(cwd, { home: fakeHome }), false);
+});
+
+test("hasRecentSessionForCwd: per-cwd dir contains .jsonl → true", () => {
+  const cwd = "/home/u/proj";
+  seedSessionFile(cwd, "abc-session-id");
+  assert.equal(hasRecentSessionForCwd(cwd, { home: fakeHome }), true);
+});
+
+test("hasRecentSessionForCwd: only non-jsonl files (e.g. memory dir) → false", () => {
+  const cwd = "/home/u/proj";
+  const dir = join(fakeHome, ".claude", "projects", encodeCwdForClaude(cwd));
+  mkdirSync(join(dir, "memory"), { recursive: true });
+  writeFileSync(join(dir, "settings.json"), "{}");
+  assert.equal(hasRecentSessionForCwd(cwd, { home: fakeHome }), false);
+});
+
+test("hasRecentSessionForCwd: a different cwd's session does not leak", () => {
+  seedSessionFile("/home/u/other", "abc");
+  assert.equal(hasRecentSessionForCwd("/home/u/proj", { home: fakeHome }), false);
+});
+
+const baseInputs = {
+  ownValues: {},
+  claudeArgs: [] as string[],
+  hasRecentSession: true,
+  env: {} as NodeJS.ProcessEnv,
+};
+
+test("shouldAutoResume: bare invocation with a saved session → true", () => {
+  assert.equal(shouldAutoResume(baseInputs), true);
+});
+
+test("shouldAutoResume: no saved session → false", () => {
+  assert.equal(shouldAutoResume({ ...baseInputs, hasRecentSession: false }), false);
+});
+
+test("shouldAutoResume: --new opts out → false", () => {
+  assert.equal(shouldAutoResume({ ...baseInputs, ownValues: { new: true } }), false);
+});
+
+test("shouldAutoResume: --list path → false", () => {
+  assert.equal(shouldAutoResume({ ...baseInputs, ownValues: { list: true } }), false);
+});
+
+test("shouldAutoResume: --model present (CLI or env collapsed) → false", () => {
+  assert.equal(shouldAutoResume({ ...baseInputs, ownValues: { model: "x" } }), false);
+});
+
+test("shouldAutoResume: any forwarded claudeArgs (positional or flag) → false", () => {
+  assert.equal(shouldAutoResume({ ...baseInputs, claudeArgs: ["--print", "hi"] }), false);
+  assert.equal(shouldAutoResume({ ...baseInputs, claudeArgs: ["explain X"] }), false);
+});
+
+test("shouldAutoResume: CLAUDELY_NO_AUTO_RESUME=1 opts out → false", () => {
+  assert.equal(
+    shouldAutoResume({ ...baseInputs, env: { CLAUDELY_NO_AUTO_RESUME: "1" } }),
+    false,
+  );
+});
+
+test("shouldAutoResume: CLAUDELY_NO_AUTO_RESUME=0/false/empty does NOT opt out", () => {
+  for (const v of ["0", "false", ""]) {
+    assert.equal(
+      shouldAutoResume({ ...baseInputs, env: { CLAUDELY_NO_AUTO_RESUME: v } }),
+      true,
+      `CLAUDELY_NO_AUTO_RESUME=${JSON.stringify(v)} should not opt out`,
+    );
+  }
 });

--- a/src/resume.test.ts
+++ b/src/resume.test.ts
@@ -1,0 +1,98 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { isResumeIntent, assembleClaudeArgv } from "./resume.js";
+
+test("isResumeIntent: empty args → false", () => {
+  assert.equal(isResumeIntent([]), false);
+});
+
+test("isResumeIntent: ordinary claude args without resume flags → false", () => {
+  assert.equal(isResumeIntent(["--print", "explain this repo"]), false);
+  assert.equal(isResumeIntent(["--effort", "high", "--debug"]), false);
+});
+
+test("isResumeIntent: -c short flag → true", () => {
+  assert.equal(isResumeIntent(["-c"]), true);
+});
+
+test("isResumeIntent: --continue long flag → true", () => {
+  assert.equal(isResumeIntent(["--continue"]), true);
+});
+
+test("isResumeIntent: -r short flag (alone, picker mode) → true", () => {
+  assert.equal(isResumeIntent(["-r"]), true);
+});
+
+test("isResumeIntent: -r with a search/id argument → true", () => {
+  assert.equal(isResumeIntent(["-r", "auth-refactor"]), true);
+});
+
+test("isResumeIntent: --resume long flag → true", () => {
+  assert.equal(isResumeIntent(["--resume"]), true);
+  assert.equal(isResumeIntent(["--resume", "session-id-123"]), true);
+});
+
+test("isResumeIntent: --resume=value (equals form) → true", () => {
+  assert.equal(isResumeIntent(["--resume=auth-refactor"]), true);
+});
+
+test("isResumeIntent: --session-id <uuid> → true", () => {
+  assert.equal(
+    isResumeIntent(["--session-id", "550e8400-e29b-41d4-a716-446655440000"]),
+    true,
+  );
+});
+
+test("isResumeIntent: --session-id=<uuid> (equals form) → true", () => {
+  assert.equal(
+    isResumeIntent(["--session-id=550e8400-e29b-41d4-a716-446655440000"]),
+    true,
+  );
+});
+
+test("isResumeIntent: --from-pr (with or without value) → true", () => {
+  assert.equal(isResumeIntent(["--from-pr"]), true);
+  assert.equal(isResumeIntent(["--from-pr", "123"]), true);
+  assert.equal(isResumeIntent(["--from-pr=123"]), true);
+});
+
+test("isResumeIntent: resume flag mixed in with other args → true", () => {
+  assert.equal(isResumeIntent(["--debug", "--continue", "--print"]), true);
+});
+
+test("isResumeIntent: a positional that LOOKS like a flag substring → false", () => {
+  // The user's prompt happens to contain the word "--continue" — must not match.
+  assert.equal(isResumeIntent(["--print", "should I --continue or stop?"]), false);
+  // Likewise something that contains "session-id" but isn't the flag.
+  assert.equal(isResumeIntent(["--print", "explain --session-id"]), false);
+});
+
+test("assembleClaudeArgv: model present → injects --model at the front", () => {
+  const out = assembleClaudeArgv({
+    model: "qwen3-coder",
+    extraArgs: ["--effort", "high"],
+    claudeArgs: ["--print", "hello"],
+  });
+  assert.deepEqual(out, ["--model", "qwen3-coder", "--effort", "high", "--print", "hello"]);
+});
+
+test("assembleClaudeArgv: model undefined (resume case) → no --model in argv", () => {
+  const out = assembleClaudeArgv({
+    model: undefined,
+    extraArgs: ["--effort", "high"],
+    claudeArgs: ["-c"],
+  });
+  assert.deepEqual(out, ["--effort", "high", "-c"]);
+  assert.equal(out.includes("--model"), false);
+});
+
+test("assembleClaudeArgv: empty extras and claude args → just the model pair (or nothing)", () => {
+  assert.deepEqual(
+    assembleClaudeArgv({ model: "m", extraArgs: [], claudeArgs: [] }),
+    ["--model", "m"],
+  );
+  assert.deepEqual(
+    assembleClaudeArgv({ model: undefined, extraArgs: [], claudeArgs: [] }),
+    [],
+  );
+});

--- a/src/resume.ts
+++ b/src/resume.ts
@@ -10,6 +10,10 @@
 //   --session-id <uuid>             use a specific session id
 //   --from-pr [value]               resume the session linked to a PR
 
+import { readdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
 const RESUME_BOOLS = new Set(["-c", "--continue"]);
 
 // Flags that are themselves resume intent regardless of their value form
@@ -36,4 +40,50 @@ export interface AssembleArgs {
 export function assembleClaudeArgv(opts: AssembleArgs): string[] {
   const head = opts.model ? ["--model", opts.model] : [];
   return [...head, ...opts.extraArgs, ...opts.claudeArgs];
+}
+
+// claude stores per-cwd sessions under ~/.claude/projects/<encoded-cwd>/.
+// The encoding replaces path separators with `-` (e.g. /home/u/x → -home-u-x).
+// We mirror that to detect "is there a previous session here?" without spawning.
+export function encodeCwdForClaude(cwd: string): string {
+  return cwd.replace(/\//g, "-");
+}
+
+export interface SessionLookupOpts {
+  // Override for tests; defaults to os.homedir().
+  home?: string;
+}
+
+export function hasRecentSessionForCwd(cwd: string, opts: SessionLookupOpts = {}): boolean {
+  const root = opts.home ?? homedir();
+  const dir = join(root, ".claude", "projects", encodeCwdForClaude(cwd));
+  try {
+    const entries = readdirSync(dir, { withFileTypes: true });
+    return entries.some((e) => e.isFile() && e.name.endsWith(".jsonl"));
+  } catch {
+    return false;
+  }
+}
+
+export interface AutoResumeInputs {
+  ownValues: {
+    model?: string | undefined;
+    list?: boolean | undefined;
+    new?: boolean | undefined;
+  };
+  claudeArgs: readonly string[];
+  hasRecentSession: boolean;
+  env: NodeJS.ProcessEnv;
+}
+
+export function shouldAutoResume(inputs: AutoResumeInputs): boolean {
+  if (!inputs.hasRecentSession) return false;
+  if (inputs.ownValues.new) return false;
+  if (inputs.ownValues.list) return false;
+  if (inputs.ownValues.model) return false;
+  if (inputs.claudeArgs.length > 0) return false;
+  if (isResumeIntent(inputs.claudeArgs)) return false;
+  const optOut = inputs.env.CLAUDELY_NO_AUTO_RESUME;
+  if (optOut && optOut !== "0" && optOut !== "" && optOut !== "false") return false;
+  return true;
 }

--- a/src/resume.ts
+++ b/src/resume.ts
@@ -80,7 +80,6 @@ export function shouldAutoResume(inputs: AutoResumeInputs): boolean {
   if (!inputs.hasRecentSession) return false;
   if (inputs.ownValues.new) return false;
   if (inputs.ownValues.list) return false;
-  if (inputs.ownValues.model) return false;
   if (inputs.claudeArgs.length > 0) return false;
   if (isResumeIntent(inputs.claudeArgs)) return false;
   const optOut = inputs.env.CLAUDELY_NO_AUTO_RESUME;

--- a/src/resume.ts
+++ b/src/resume.ts
@@ -1,0 +1,39 @@
+// Detect "resume" intent in the args claudely is about to forward to claude,
+// and decide whether to inject `--model`. When the user is resuming a saved
+// session, the model is already encoded in that session — picking again
+// (interactive picker) and re-injecting `--model` is at best wasted UX and
+// at worst overrides what the saved session asked for.
+//
+// Flags considered resume-intent (per `claude --help`):
+//   -c, --continue                  resume most recent session in cwd
+//   -r, --resume [value]            resume by id, or interactive picker
+//   --session-id <uuid>             use a specific session id
+//   --from-pr [value]               resume the session linked to a PR
+
+const RESUME_BOOLS = new Set(["-c", "--continue"]);
+
+// Flags that are themselves resume intent regardless of their value form
+// (`--flag`, `--flag=value`, or `--flag value`).
+const RESUME_VALUEY = new Set(["-r", "--resume", "--session-id", "--from-pr"]);
+
+export function isResumeIntent(claudeArgs: readonly string[]): boolean {
+  for (const arg of claudeArgs) {
+    if (RESUME_BOOLS.has(arg)) return true;
+    if (RESUME_VALUEY.has(arg)) return true;
+    const eq = arg.indexOf("=");
+    if (eq > 0 && RESUME_VALUEY.has(arg.slice(0, eq))) return true;
+  }
+  return false;
+}
+
+export interface AssembleArgs {
+  // undefined when caller has decided not to inject --model (resume case).
+  model: string | undefined;
+  extraArgs: readonly string[];
+  claudeArgs: readonly string[];
+}
+
+export function assembleClaudeArgv(opts: AssembleArgs): string[] {
+  const head = opts.model ? ["--model", opts.model] : [];
+  return [...head, ...opts.extraArgs, ...opts.claudeArgs];
+}


### PR DESCRIPTION
## Summary

Bumps to 0.1.4. Bundles three behavioral changes around resume + a small README polish:

- **Auto-resume on bare `claudely`** — when a saved session exists for the cwd and no other intent is signaled, pushes `--continue` onto the spawned argv. New `--new` flag and `CLAUDELY_NO_AUTO_RESUME=1` env var as opt-outs.
- **Skip the model picker on explicit resume** — `-c` / `--continue` / `-r` / `--resume` / `--session-id` / `--from-pr` no longer trigger the picker, since the saved session already encodes its model.
- **Decouple model selection from resume detection** — `claudely --model X` now auto-resumes and passes `--model X` through; `claudely -c --model X` no longer silently drops the explicit model. Env-derived model defaults (`CLAUDELY_MODEL`, etc.) are skipped on resume since they're "default for fresh," not "intent to override saved."

Plus: README gains npm version / downloads / license badges and a note about the `@anthropic-ai/claude-code` peer dependency.

Closes #8
Closes #9
Closes #10

## Test plan

- [ ] `npm test` passes (existing + 14 new unit tests in `src/resume.test.ts` covering `encodeCwdForClaude`, `hasRecentSessionForCwd`, `shouldAutoResume`, `isResumeIntent`, `assembleClaudeArgv`)
- [ ] `claudely` (no args, cwd has saved session) → resumes, prints `claudely: resuming previous session ...` to stderr
- [ ] `claudely --new` (cwd has saved session) → fresh session, no resume
- [ ] `claudely --model X` (cwd has saved session) → auto-resumes AND forwards `--model X`
- [ ] `claudely -c --model X` → forwards `--model X` (not silently dropped)
- [ ] `claudely -c` → skips the model picker
- [ ] `CLAUDELY_NO_AUTO_RESUME=1 claudely` (cwd has saved session) → fresh session