### PR TITLE
test: real-subprocess integration tests for lms / ollama listers

### DIFF
--- a/src/listers.integration.test.ts
+++ b/src/listers.integration.test.ts
@@ -13,11 +13,11 @@ import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from "no
 import { tmpdir } from "node:os";
 import { join, delimiter } from "node:path";
 import { listLmStudio, listOllama } from "./listers.js";
+import { restoreFetch, mockFetch } from "./test-helpers.js";
 
 // POSIX-only: skip on Windows since the fakes use sh shebangs.
 const skipOnWindows = { skip: process.platform === "win32" ? "POSIX-only" : false };
 
-const realFetch = globalThis.fetch;
 const realPath = process.env.PATH;
 let tempDir: string;
 let argvLog: string;
@@ -27,12 +27,12 @@ beforeEach(() => {
   tempDir = mkdtempSync(join(tmpdir(), "claudely-listers-"));
   emptyDir = mkdtempSync(join(tmpdir(), "claudely-empty-"));
   argvLog = join(tempDir, "argv.log");
-  globalThis.fetch = realFetch;
+  restoreFetch();
 });
 
 afterEach(() => {
   process.env.PATH = realPath;
-  globalThis.fetch = realFetch;
+  restoreFetch();
   rmSync(tempDir, { recursive: true, force: true });
   rmSync(emptyDir, { recursive: true, force: true });
 });
@@ -49,14 +49,6 @@ function prependToPath(dir: string): void {
 function readArgvLog(): string[] {
   if (!existsSync(argvLog)) return [];
   return readFileSync(argvLog, "utf8").trim().split("\n");
-}
-
-function mockFetch(response: Partial<Response> & { json?: () => Promise<unknown> }): void {
-  globalThis.fetch = (async () => ({
-    ok: true,
-    json: async () => ({}),
-    ...response,
-  })) as typeof fetch;
 }
 
 test(
@@ -101,6 +93,7 @@ test(
   "listLmStudio: ENOENT (binary missing on PATH) → falls back to listV1Models",
   skipOnWindows,
   async () => {
+    // Intentionally clobber PATH: the fallback (listV1Models) uses fetch, not execFile.
     process.env.PATH = emptyDir;
     mockFetch({ ok: true, json: async () => ({ data: [{ id: "fallback-model" }] }) });
 
@@ -165,6 +158,7 @@ test(
   "listOllama: ENOENT (binary missing on PATH) → falls back to listV1Models",
   skipOnWindows,
   async () => {
+    // Intentionally clobber PATH: the fallback (listV1Models) uses fetch, not execFile.
     process.env.PATH = emptyDir;
     mockFetch({ ok: true, json: async () => ({ data: [{ id: "fallback-model" }] }) });
 

--- a/src/listers.integration.test.ts
+++ b/src/listers.integration.test.ts
@@ -1,0 +1,197 @@
+// Real-subprocess integration tests for the listers.
+//
+// Unlike listers.test.ts (which injects a fake Runner), these tests exercise
+// the actual `promisify(execFile)` path: PATH lookup, ENOENT bubbling, exit
+// codes, stderr capture, and the JSON shape we expect from real
+// `lms ls --json` / `ollama list`. We do NOT depend on LM Studio or Ollama
+// being installed — instead, we drop fake shell scripts onto a temp dir and
+// prepend it to PATH for the duration of each test.
+
+import { test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, delimiter } from "node:path";
+import { listLmStudio, listOllama } from "./listers.js";
+
+// POSIX-only: skip on Windows since the fakes use sh shebangs.
+const skipOnWindows = { skip: process.platform === "win32" ? "POSIX-only" : false };
+
+const realFetch = globalThis.fetch;
+const realPath = process.env.PATH;
+let tempDir: string;
+let argvLog: string;
+let emptyDir: string;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), "claudely-listers-"));
+  emptyDir = mkdtempSync(join(tmpdir(), "claudely-empty-"));
+  argvLog = join(tempDir, "argv.log");
+  globalThis.fetch = realFetch;
+});
+
+afterEach(() => {
+  process.env.PATH = realPath;
+  globalThis.fetch = realFetch;
+  rmSync(tempDir, { recursive: true, force: true });
+  rmSync(emptyDir, { recursive: true, force: true });
+});
+
+function installFake(name: string, body: string): void {
+  const path = join(tempDir, name);
+  writeFileSync(path, body, { mode: 0o755 });
+}
+
+function prependToPath(dir: string): void {
+  process.env.PATH = `${dir}${delimiter}${realPath ?? ""}`;
+}
+
+function readArgvLog(): string[] {
+  if (!existsSync(argvLog)) return [];
+  return readFileSync(argvLog, "utf8").trim().split("\n");
+}
+
+function mockFetch(response: Partial<Response> & { json?: () => Promise<unknown> }): void {
+  globalThis.fetch = (async () => ({
+    ok: true,
+    json: async () => ({}),
+    ...response,
+  })) as typeof fetch;
+}
+
+test(
+  "listLmStudio: real subprocess — PATH lookup, JSON parse, argv assertion",
+  skipOnWindows,
+  async () => {
+    installFake(
+      "lms",
+      `#!/usr/bin/env sh
+echo "$@" >> "${argvLog}"
+case "$1" in
+  ls)
+    cat <<'JSON'
+[{"modelKey":"qwen3-coder","displayName":"Qwen3 Coder","paramsString":"8B","quantization":{"name":"Q4_K_M"},"trainedForToolUse":true}]
+JSON
+    ;;
+  ps)
+    echo "[]"
+    ;;
+esac
+`,
+    );
+    prependToPath(tempDir);
+
+    const result = await listLmStudio("http://localhost:1234", "tok");
+
+    assert.deepEqual(result, [
+      {
+        id: "qwen3-coder",
+        display: "Qwen3 Coder",
+        extras: ["8B", "Q4_K_M", "tools"],
+        loaded: false,
+      },
+    ]);
+
+    const argv = readArgvLog().sort();
+    assert.deepEqual(argv, ["ls --llm --json", "ps --json"]);
+  },
+);
+
+test(
+  "listLmStudio: ENOENT (binary missing on PATH) → falls back to listV1Models",
+  skipOnWindows,
+  async () => {
+    process.env.PATH = emptyDir;
+    mockFetch({ ok: true, json: async () => ({ data: [{ id: "fallback-model" }] }) });
+
+    const result = await listLmStudio("http://localhost:1234", "tok");
+
+    assert.deepEqual(result, [{ id: "fallback-model", display: "fallback-model", extras: [] }]);
+  },
+);
+
+test(
+  "listLmStudio: nonzero exit (real stderr/exitcode bubbles) → falls back to listV1Models",
+  skipOnWindows,
+  async () => {
+    installFake(
+      "lms",
+      `#!/usr/bin/env sh
+echo "$@" >> "${argvLog}"
+echo "boom" >&2
+exit 1
+`,
+    );
+    prependToPath(tempDir);
+    mockFetch({ ok: true, json: async () => ({ data: [{ id: "fallback-model" }] }) });
+
+    const result = await listLmStudio("http://localhost:1234", "tok");
+
+    assert.deepEqual(result, [{ id: "fallback-model", display: "fallback-model", extras: [] }]);
+    // Both calls were attempted before falling back.
+    const argv = readArgvLog().sort();
+    assert.deepEqual(argv, ["ls --llm --json", "ps --json"]);
+  },
+);
+
+test(
+  "listOllama: real subprocess — PATH lookup, table parse, argv assertion",
+  skipOnWindows,
+  async () => {
+    installFake(
+      "ollama",
+      `#!/usr/bin/env sh
+echo "$@" >> "${argvLog}"
+cat <<'TABLE'
+NAME                ID              SIZE    MODIFIED
+qwen3:8b            abc123def456    4.7 GB  2 days ago
+llama3:latest       fed987cba321    4.1 GB  3 weeks ago
+TABLE
+`,
+    );
+    prependToPath(tempDir);
+
+    const result = await listOllama("http://localhost:11434", "tok");
+
+    assert.deepEqual(result, [
+      { id: "qwen3:8b", display: "qwen3:8b", extras: ["4.7 GB", "2 days ago"] },
+      { id: "llama3:latest", display: "llama3:latest", extras: ["4.1 GB", "3 weeks ago"] },
+    ]);
+    assert.deepEqual(readArgvLog(), ["list"]);
+  },
+);
+
+test(
+  "listOllama: ENOENT (binary missing on PATH) → falls back to listV1Models",
+  skipOnWindows,
+  async () => {
+    process.env.PATH = emptyDir;
+    mockFetch({ ok: true, json: async () => ({ data: [{ id: "fallback-model" }] }) });
+
+    const result = await listOllama("http://localhost:11434", "tok");
+
+    assert.deepEqual(result, [{ id: "fallback-model", display: "fallback-model", extras: [] }]);
+  },
+);
+
+test(
+  "listOllama: nonzero exit (real stderr/exitcode bubbles) → falls back to listV1Models",
+  skipOnWindows,
+  async () => {
+    installFake(
+      "ollama",
+      `#!/usr/bin/env sh
+echo "$@" >> "${argvLog}"
+echo "boom" >&2
+exit 2
+`,
+    );
+    prependToPath(tempDir);
+    mockFetch({ ok: true, json: async () => ({ data: [{ id: "fallback-model" }] }) });
+
+    const result = await listOllama("http://localhost:11434", "tok");
+
+    assert.deepEqual(result, [{ id: "fallback-model", display: "fallback-model", extras: [] }]);
+    assert.deepEqual(readArgvLog(), ["list"]);
+  },
+);

--- a/src/listers.test.ts
+++ b/src/listers.test.ts
@@ -1,6 +1,7 @@
 import { test, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
 import { listLmStudio, listOllama, listV1Models, type Runner } from "./listers.js";
+import { restoreFetch, mockFetch } from "./test-helpers.js";
 
 function fakeRun(responses: Record<string, string | Error>): Runner {
   return async (cmd: string, args: string[]) => {
@@ -25,23 +26,13 @@ function mockV1Fallback(id = "fallback-model") {
   });
 }
 
-const realFetch = globalThis.fetch;
-
 beforeEach(() => {
-  globalThis.fetch = realFetch;
+  restoreFetch();
 });
 
 afterEach(() => {
-  globalThis.fetch = realFetch;
+  restoreFetch();
 });
-
-function mockFetch(response: Partial<Response> & { json?: () => Promise<unknown> }) {
-  globalThis.fetch = (async () => ({
-    ok: true,
-    json: async () => ({}),
-    ...response,
-  })) as typeof fetch;
-}
 
 test("listV1Models parses /v1/models data into ModelEntry[] with empty extras", async () => {
   mockFetch({

--- a/src/test-helpers.ts
+++ b/src/test-helpers.ts
@@ -1,0 +1,17 @@
+const realFetch = globalThis.fetch;
+
+export function captureRealFetch(): typeof fetch {
+  return realFetch;
+}
+
+export function restoreFetch(): void {
+  globalThis.fetch = realFetch;
+}
+
+export function mockFetch(response: Partial<Response> & { json?: () => Promise<unknown> }): void {
+  globalThis.fetch = (async () => ({
+    ok: true,
+    json: async () => ({}),
+    ...response,
+  })) as typeof fetch;
+}


### PR DESCRIPTION
## Summary

Closes #3.

Adds \`src/listers.integration.test.ts\` — 6 hermetic integration tests that exercise the real \`promisify(execFile)\` path through \`listLmStudio\` / \`listOllama\` without depending on LM Studio or Ollama being installed.

Approach is exactly what #3 proposed: drop fake POSIX shell scripts named \`lms\` / \`ollama\` onto a temp dir, prepend it to \`PATH\`, call the listers without injecting a \`Runner\`, and assert both the parsed result and the argv the script received (echoed to a sidecar log file).

### What's covered

| Lister | Happy path | ENOENT (binary missing) | Nonzero exit |
|---|---|---|---|
| \`listLmStudio\` | ✅ argv \`ls --llm --json\` + \`ps --json\`, JSON parse, loaded/extras | ✅ falls back to \`listV1Models\` | ✅ both calls attempted, then fallback |
| \`listOllama\` | ✅ argv \`list\`, table parse, two-row output | ✅ falls back to \`listV1Models\` | ✅ falls back to \`listV1Models\` |

The \`listV1Models\` branches are verified by stubbing \`globalThis.fetch\` to return a canned \`/v1/models\` payload — keeps the tests offline and dependency-free.

### Acceptance checklist (from #3)

- [x] At least one integration test per lister that spawns a real subprocess via PATH lookup
- [x] Argv assertion (the script wrote what we expected)
- [x] ENOENT path verified (lister falls back to \`listV1Models\`)
- [x] Tests run on Node 20 & 22 in existing CI matrix without new runtime deps

### Out of scope (per #3)

- No tests against real LM Studio / Ollama servers
- Windows runners (skipOnWindows guard; \`.cmd\` shim deferred until Windows is in the CI matrix)

## Test plan

- [x] \`npm test\` — 79 tests pass (73 existing + 6 new integration)
- [ ] CI matrix (Node 20 + 22) green on this PR