### PR TITLE
feat: claudely setup interactive wizard + config persistence

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -23,7 +23,7 @@ import {
   type ModelEntry,
 } from "./listers.js";
 import { applyCompat } from "./compat.js";
-import { loadSettings } from "./config.js";
+import { loadSettings, loadConfig } from "./config.js";
 import { splitArgs, type FlagSpec } from "./argsplit.js";
 import { renderVersion } from "./version.js";
 import {
@@ -134,6 +134,7 @@ async function main(): Promise<number> {
   }
 
   const { values } = parsed;
+  const config = loadConfig();
 
   if (values.help) {
     console.log(HELP);
@@ -145,7 +146,7 @@ async function main(): Promise<number> {
     return 0;
   }
 
-  const providerName = values.provider ?? process.env.CLAUDELY_PROVIDER ?? "lmstudio";
+  const providerName = values.provider ?? process.env.CLAUDELY_PROVIDER ?? config.provider ?? "lmstudio";
   const provider = PROVIDERS[providerName];
   if (!provider) {
     console.error(
@@ -155,8 +156,8 @@ async function main(): Promise<number> {
   }
 
   const baseUrl =
-    values["base-url"] ?? process.env.CLAUDELY_BASE_URL ?? provider.defaultBaseUrl();
-  const token = values.token ?? process.env.CLAUDELY_TOKEN ?? provider.defaultToken;
+    values["base-url"] ?? process.env.CLAUDELY_BASE_URL ?? config.baseUrl ?? provider.defaultBaseUrl();
+  const token = values.token ?? process.env.CLAUDELY_TOKEN ?? config.token ?? provider.defaultToken;
 
   if (!baseUrl) {
     console.error(
@@ -208,6 +209,7 @@ async function main(): Promise<number> {
   if (!model && !resuming) {
     model =
       process.env.CLAUDELY_MODEL ??
+      config.model ??
       (provider.modelEnvVar ? process.env[provider.modelEnvVar] : undefined);
 
     if (!model) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -25,6 +25,7 @@ import {
 import { applyCompat } from "./compat.js";
 import { loadSettings, loadConfig } from "./config.js";
 import { splitArgs, type FlagSpec } from "./argsplit.js";
+import { runSetup } from "./setup.js";
 import { renderVersion } from "./version.js";
 import {
   isResumeIntent,
@@ -57,6 +58,7 @@ claudely options:
       --new               Force a fresh session (skip auto-resume)
   -h, --help              Show this help
   -V, --version           Print claudely and claude versions, then exit
+      setup               Configure provider, URL, token, and default model
 
 Bare \`claudely\` (no args, no --model) auto-resumes the most recent
 claude session for the current directory when one exists. Use --new to
@@ -72,6 +74,7 @@ Use \`--\` as an escape hatch to force a token through (e.g. when claude
 gains a flag whose name collides with one of claudely's own).
 
 Examples:
+  claudely setup                                     # interactive config wizard
   claudely                                       # LM Studio + interactive picker
   claudely -p ollama                             # Ollama
   claudely -p llamacpp                           # llama.cpp
@@ -105,6 +108,10 @@ function listForProvider(
 }
 
 async function main(): Promise<number> {
+  if (process.argv[2] === "setup") {
+    return runSetup();
+  }
+
   // Anything claudely doesn't recognize as one of its own flags is forwarded
   // to claude. Use `--` as an explicit escape hatch to force a token through
   // (e.g. when claude has a flag that collides with one of ours).

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,7 +22,8 @@ import {
   listV1Models,
   type ModelEntry,
 } from "./listers.js";
-import { applyCompat, loadSettings } from "./compat.js";
+import { applyCompat } from "./compat.js";
+import { loadSettings } from "./config.js";
 import { splitArgs, type FlagSpec } from "./argsplit.js";
 import { renderVersion } from "./version.js";
 import {

--- a/src/compat.test.ts
+++ b/src/compat.test.ts
@@ -3,7 +3,8 @@ import assert from "node:assert/strict";
 import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { applyCompat, loadSettings, type Incompatibility } from "./compat.js";
+import { applyCompat, type Incompatibility } from "./compat.js";
+import { loadSettings } from "./config.js";
 
 test("effortLevel xhigh against non-Anthropic: warning + ['--effort','high']", () => {
   const result = applyCompat({

--- a/src/compat.test.ts
+++ b/src/compat.test.ts
@@ -1,10 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
-import { join } from "node:path";
-import { tmpdir } from "node:os";
 import { applyCompat, type Incompatibility } from "./compat.js";
-import { loadSettings } from "./config.js";
 
 test("effortLevel xhigh against non-Anthropic: warning + ['--effort','high']", () => {
   const result = applyCompat({
@@ -61,38 +57,6 @@ test("undefined settings (missing/malformed file): no-op", () => {
     }),
     { warnings: [], extraArgs: [] },
   );
-});
-
-test("loadSettings returns parsed object for a valid file", () => {
-  const dir = mkdtempSync(join(tmpdir(), "claudely-test-"));
-  try {
-    const path = join(dir, "settings.json");
-    writeFileSync(path, JSON.stringify({ effortLevel: "xhigh", other: 1 }));
-    assert.deepEqual(loadSettings(path), { effortLevel: "xhigh", other: 1 });
-  } finally {
-    rmSync(dir, { recursive: true, force: true });
-  }
-});
-
-test("loadSettings returns undefined for missing, malformed, or non-object JSON", () => {
-  const dir = mkdtempSync(join(tmpdir(), "claudely-test-"));
-  try {
-    assert.equal(loadSettings(join(dir, "nope.json")), undefined);
-
-    const bad = join(dir, "bad.json");
-    writeFileSync(bad, "{ not valid json");
-    assert.equal(loadSettings(bad), undefined);
-
-    const arr = join(dir, "arr.json");
-    writeFileSync(arr, "[1,2,3]");
-    assert.equal(loadSettings(arr), undefined);
-
-    const lit = join(dir, "lit.json");
-    writeFileSync(lit, '"a string"');
-    assert.equal(loadSettings(lit), undefined);
-  } finally {
-    rmSync(dir, { recursive: true, force: true });
-  }
 });
 
 test("safe / unset / unknown setting values: no-op", () => {

--- a/src/compat.ts
+++ b/src/compat.ts
@@ -1,20 +1,7 @@
-import { readFileSync } from "node:fs";
-
 export interface ApplyContext {
   settings: Record<string, unknown> | undefined;
   baseUrl: string;
   existingClaudeArgs: readonly string[];
-}
-
-export function loadSettings(settingsPath: string): Record<string, unknown> | undefined {
-  try {
-    const parsed = JSON.parse(readFileSync(settingsPath, "utf8")) as unknown;
-    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
-      ? (parsed as Record<string, unknown>)
-      : undefined;
-  } catch {
-    return undefined;
-  }
 }
 
 export interface CompatResult {

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,0 +1,193 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir, homedir } from "node:os";
+import { configDir, configPath, loadConfig, saveConfig, loadSettings } from "./config.js";
+
+// --- platform mocking helpers ---
+const originalPlatform = Object.getOwnPropertyDescriptor(process, "platform")!;
+function mockPlatform(value: string) {
+  Object.defineProperty(process, "platform", { value, configurable: true });
+}
+function restorePlatform() {
+  Object.defineProperty(process, "platform", originalPlatform);
+}
+
+// --- configDir platform tests ---
+
+test("configDir on linux uses $XDG_CONFIG_HOME/claudely when set", () => {
+  const saved = process.env.XDG_CONFIG_HOME;
+  try {
+    mockPlatform("linux");
+    process.env.XDG_CONFIG_HOME = "/tmp/custom-xdg";
+    assert.equal(configDir(), "/tmp/custom-xdg/claudely");
+  } finally {
+    restorePlatform();
+    if (saved === undefined) delete process.env.XDG_CONFIG_HOME;
+    else process.env.XDG_CONFIG_HOME = saved;
+  }
+});
+
+test("configDir on linux defaults to ~/.config/claudely when XDG unset", () => {
+  const saved = process.env.XDG_CONFIG_HOME;
+  try {
+    mockPlatform("linux");
+    delete process.env.XDG_CONFIG_HOME;
+    assert.equal(configDir(), join(homedir(), ".config", "claudely"));
+  } finally {
+    restorePlatform();
+    if (saved === undefined) delete process.env.XDG_CONFIG_HOME;
+    else process.env.XDG_CONFIG_HOME = saved;
+  }
+});
+
+test("configDir on darwin uses Library/Application Support/claudely", () => {
+  try {
+    mockPlatform("darwin");
+    assert.equal(configDir(), join(homedir(), "Library", "Application Support", "claudely"));
+  } finally {
+    restorePlatform();
+  }
+});
+
+test("configDir on win32 uses APPDATA/claudely", () => {
+  const saved = process.env.APPDATA;
+  try {
+    mockPlatform("win32");
+    process.env.APPDATA = "C:\\Users\\test\\AppData\\Roaming";
+    assert.equal(configDir(), join("C:\\Users\\test\\AppData\\Roaming", "claudely"));
+  } finally {
+    restorePlatform();
+    if (saved === undefined) delete process.env.APPDATA;
+    else process.env.APPDATA = saved;
+  }
+});
+
+test("configPath ends with config.json", () => {
+  assert.ok(configPath().endsWith("config.json"));
+});
+
+// --- loadConfig / saveConfig tests ---
+
+test("round-trip: saveConfig then loadConfig returns same object", () => {
+  const dir = mkdtempSync(join(tmpdir(), "claudely-cfg-"));
+  const savedXDG = process.env.XDG_CONFIG_HOME;
+  try {
+    mockPlatform("linux");
+    process.env.XDG_CONFIG_HOME = dir;
+    const config = { provider: "ollama", baseUrl: "http://localhost:11434", model: "llama3" };
+    saveConfig(config);
+    const loaded = loadConfig();
+    assert.deepEqual(loaded, config);
+  } finally {
+    restorePlatform();
+    if (savedXDG === undefined) delete process.env.XDG_CONFIG_HOME;
+    else process.env.XDG_CONFIG_HOME = savedXDG;
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("loadConfig returns {} for missing file", () => {
+  const dir = mkdtempSync(join(tmpdir(), "claudely-cfg-"));
+  const savedXDG = process.env.XDG_CONFIG_HOME;
+  try {
+    mockPlatform("linux");
+    process.env.XDG_CONFIG_HOME = dir;
+    // No config file exists in this temp dir
+    assert.deepEqual(loadConfig(), {});
+  } finally {
+    restorePlatform();
+    if (savedXDG === undefined) delete process.env.XDG_CONFIG_HOME;
+    else process.env.XDG_CONFIG_HOME = savedXDG;
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("loadConfig returns {} and writes warning to stderr for corrupt JSON", () => {
+  const dir = mkdtempSync(join(tmpdir(), "claudely-cfg-"));
+  const savedXDG = process.env.XDG_CONFIG_HOME;
+  try {
+    mockPlatform("linux");
+    process.env.XDG_CONFIG_HOME = dir;
+
+    // Create the claudely subdirectory and write corrupt JSON
+    const cfgDir = join(dir, "claudely");
+    mkdirSync(cfgDir, { recursive: true });
+    writeFileSync(join(cfgDir, "config.json"), "{ not valid json !!!");
+
+    // Capture stderr
+    const chunks: string[] = [];
+    const origWrite = process.stderr.write;
+    process.stderr.write = ((chunk: string | Uint8Array) => {
+      chunks.push(typeof chunk === "string" ? chunk : chunk.toString());
+      return true;
+    }) as typeof process.stderr.write;
+
+    try {
+      const result = loadConfig();
+      assert.deepEqual(result, {});
+      assert.ok(chunks.some((c) => c.includes("corrupt")), "expected stderr warning about corrupt config");
+    } finally {
+      process.stderr.write = origWrite;
+    }
+  } finally {
+    restorePlatform();
+    if (savedXDG === undefined) delete process.env.XDG_CONFIG_HOME;
+    else process.env.XDG_CONFIG_HOME = savedXDG;
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("saveConfig creates parent directories if missing", () => {
+  const dir = mkdtempSync(join(tmpdir(), "claudely-cfg-"));
+  const savedXDG = process.env.XDG_CONFIG_HOME;
+  try {
+    mockPlatform("linux");
+    // Point XDG to a non-existent subdirectory
+    const nested = join(dir, "deeply", "nested");
+    process.env.XDG_CONFIG_HOME = nested;
+    assert.ok(!existsSync(nested));
+    saveConfig({ provider: "test" });
+    assert.ok(existsSync(join(nested, "claudely", "config.json")));
+  } finally {
+    restorePlatform();
+    if (savedXDG === undefined) delete process.env.XDG_CONFIG_HOME;
+    else process.env.XDG_CONFIG_HOME = savedXDG;
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// --- loadSettings tests (moved from compat.test.ts) ---
+
+test("loadSettings returns parsed object for a valid file", () => {
+  const dir = mkdtempSync(join(tmpdir(), "claudely-test-"));
+  try {
+    const path = join(dir, "settings.json");
+    writeFileSync(path, JSON.stringify({ effortLevel: "xhigh", other: 1 }));
+    assert.deepEqual(loadSettings(path), { effortLevel: "xhigh", other: 1 });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("loadSettings returns undefined for missing, malformed, or non-object JSON", () => {
+  const dir = mkdtempSync(join(tmpdir(), "claudely-test-"));
+  try {
+    assert.equal(loadSettings(join(dir, "nope.json")), undefined);
+
+    const bad = join(dir, "bad.json");
+    writeFileSync(bad, "{ not valid json");
+    assert.equal(loadSettings(bad), undefined);
+
+    const arr = join(dir, "arr.json");
+    writeFileSync(arr, "[1,2,3]");
+    assert.equal(loadSettings(arr), undefined);
+
+    const lit = join(dir, "lit.json");
+    writeFileSync(lit, '"a string"');
+    assert.equal(loadSettings(lit), undefined);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,52 @@
+import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+export interface ClaudelyConfig {
+  provider?: string;
+  baseUrl?: string;
+  token?: string;
+  model?: string;
+}
+
+export function configDir(): string {
+  switch (process.platform) {
+    case "win32":
+      return join(process.env.APPDATA ?? join(homedir(), "AppData", "Roaming"), "claudely");
+    case "darwin":
+      return join(homedir(), "Library", "Application Support", "claudely");
+    default:
+      return join(process.env.XDG_CONFIG_HOME ?? join(homedir(), ".config"), "claudely");
+  }
+}
+
+export function configPath(): string {
+  return join(configDir(), "config.json");
+}
+
+export function loadConfig(): ClaudelyConfig {
+  try {
+    return JSON.parse(readFileSync(configPath(), "utf8")) as ClaudelyConfig;
+  } catch (err) {
+    if (err && typeof err === "object" && "code" in err && err.code === "ENOENT") return {};
+    process.stderr.write("claudely: warning: corrupt config file, using defaults\n");
+    return {};
+  }
+}
+
+export function saveConfig(config: ClaudelyConfig): void {
+  const dir = configDir();
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "config.json"), JSON.stringify(config, null, 2) + "\n");
+}
+
+export function loadSettings(settingsPath: string): Record<string, unknown> | undefined {
+  try {
+    const parsed = JSON.parse(readFileSync(settingsPath, "utf8")) as unknown;
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -38,10 +38,9 @@ export const PROVIDERS: Record<string, Provider> = {
   llamacpp: {
     name: "llamacpp",
     defaultBaseUrl: () => `http://localhost:${process.env.LLAMACPP_PORT ?? "8080"}`,
-    // llama-server expects the key in ANTHROPIC_API_KEY, per unsloth's docs.
     defaultToken: "sk-no-key-required",
     modelEnvVar: "LLAMACPP_MODEL",
-    envStyle: "api_key",
+    envStyle: "auth_token",
     lister: "v1_models",
     startHint: "llama-server --port 8080 -m /path/to/model.gguf",
   },

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -1,0 +1,94 @@
+import { select, input, confirm } from "@inquirer/prompts";
+import { PROVIDERS, PROVIDER_NAMES, type Provider } from "./providers.js";
+import { listLmStudio, listOllama, listV1Models, type ModelEntry } from "./listers.js";
+import { loadConfig, saveConfig, type ClaudelyConfig } from "./config.js";
+
+function listForProvider(
+  provider: Provider,
+  baseUrl: string,
+  token: string,
+): Promise<ModelEntry[]> {
+  switch (provider.lister) {
+    case "lmstudio":
+      return listLmStudio(baseUrl, token);
+    case "ollama":
+      return listOllama(baseUrl, token);
+    case "v1_models":
+      return listV1Models(baseUrl, token);
+  }
+}
+
+export async function runSetup(): Promise<number> {
+  const existing = loadConfig();
+
+  const providerName = await select({
+    message: "Provider",
+    choices: PROVIDER_NAMES.map(name => ({ name, value: name })),
+    default: existing.provider ?? "lmstudio",
+  });
+
+  const provider = PROVIDERS[providerName];
+
+  const baseUrl = await input({
+    message: "Base URL",
+    default: existing.baseUrl ?? provider.defaultBaseUrl(),
+  });
+
+  const token = await input({
+    message: "Auth token",
+    default: existing.token ?? provider.defaultToken,
+  });
+
+  let models: ModelEntry[] = [];
+  try {
+    const res = await fetch(`${baseUrl}/v1/models`, {
+      signal: AbortSignal.timeout(5000),
+    });
+    if (res.ok) {
+      models = await listForProvider(provider, baseUrl, token);
+      console.log(`  Connected — ${models.length} model(s) found.`);
+    } else {
+      console.log(`  Server responded ${res.status} — skipping model discovery.`);
+    }
+  } catch {
+    console.log("  Could not reach server — you can still save and connect later.");
+  }
+
+  let model: string | undefined;
+  if (models.length > 0) {
+    const choices = models.map(m => ({ name: m.display, value: m.id }));
+    choices.push({ name: "(skip — no default model)", value: "" });
+    const picked = await select({
+      message: "Default model",
+      choices,
+      default: existing.model ?? undefined,
+    });
+    if (picked) model = picked;
+  } else {
+    const manual = await input({
+      message: "Default model (Enter to skip)",
+      default: existing.model ?? "",
+    });
+    if (manual) model = manual;
+  }
+
+  const config: ClaudelyConfig = { provider: providerName, baseUrl, token };
+  if (model) config.model = model;
+
+  console.log("\nConfig to save:");
+  console.log(`  provider:  ${config.provider}`);
+  console.log(`  baseUrl:   ${config.baseUrl}`);
+  console.log(`  token:     ${config.token}`);
+  if (config.model) console.log(`  model:     ${config.model}`);
+  console.log();
+
+  const ok = await confirm({ message: "Save?", default: true });
+  if (!ok) {
+    console.log("Aborted — nothing saved.");
+    return 0;
+  }
+
+  saveConfig(config);
+  console.log("Saved. Run `claudely` to use your new config.");
+  return 0;
+}

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -42,6 +42,7 @@ export async function runSetup(): Promise<number> {
   let models: ModelEntry[] = [];
   try {
     const res = await fetch(`${baseUrl}/v1/models`, {
+      headers: { Authorization: `Bearer ${token}` },
       signal: AbortSignal.timeout(5000),
     });
     if (res.ok) {


### PR DESCRIPTION
## Summary

Adds `claudely setup` — an interactive wizard that configures provider, base URL, auth token, and default model. Persists to a platform-native config file and loads on every subsequent `claudely` run.

Closes #14

### What's included

- **`src/config.ts`** (new) — all config I/O consolidated: `configDir()` (XDG/macOS/Windows), `loadConfig()`, `saveConfig()`, plus `loadSettings()` moved from compat.ts
- **`src/setup.ts`** (new) — interactive wizard: provider picker → base URL → auth token → connection test with model discovery → default model → confirm & save
- **`src/config.test.ts`** (new) — 11 unit tests: platform paths, round-trip, missing/corrupt file, directory creation, loadSettings
- **`src/compat.ts`** — `loadSettings` removed, pure business logic only (no more `fs` import)
- **`src/cli.ts`** — `setup` subcommand dispatch, config threaded into resolution chain (CLI flag > env var > config > provider default)
- **`src/providers.ts`** — llamacpp switched to `auth_token` envStyle (fixes 401 for Claude Max users)

### Bug fixes included

- **Setup wizard connection test** now sends `Authorization: Bearer` header (was missing, caused silent 401 on servers requiring auth)
- **llamacpp provider** switched from `api_key` to `auth_token` envStyle — Claude Max users' OAuth session token was overriding `ANTHROPIC_API_KEY`, causing the local server to reject requests with 401

## Test plan

- [x] `npm test` — 87 pass (1 pre-existing flaky lister test)
- [x] `npm run build` — clean compile
- [x] `claudely setup` — wizard runs, discovers models, saves config
- [x] `claudely --new --print "hello"` — reads saved config, connects to llama-server
- [x] llamacpp auth verified via curl (x-api-key + Bearer both work on /v1/messages)
- [x] CI matrix (Node 20 + 22) green