### PR TITLE
chore: bump to 0.1.5 (setup wizard + auth fixes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,32 @@ section is also used as the body of the Release notes by the
 
 ## [Unreleased]
 
+## [0.1.5] - 2026-05-03
+
+### Added
+- `claudely setup` interactive wizard: walks through provider, base URL,
+  auth token, connection test with model discovery, and default model
+  selection. Saves to a platform-native config file (`~/.config/claudely/`
+  on Linux, `~/Library/Application Support/claudely/` on macOS,
+  `%APPDATA%\claudely\` on Windows).
+- Persistent config loaded on every run. Precedence: CLI flag > env var >
+  config file > provider default.
+- New `src/config.ts` consolidates all config I/O: `configDir()`,
+  `configPath()`, `loadConfig()`, `saveConfig()`, and `loadSettings()`
+  (moved from compat.ts to decouple I/O from business logic).
+
+### Fixed
+- llamacpp provider switched from `api_key` to `auth_token` envStyle —
+  fixes 401 errors for Claude Max users whose OAuth session token was
+  overriding `ANTHROPIC_API_KEY`.
+- Setup wizard connection test now sends `Authorization: Bearer` header —
+  previously fetched `/v1/models` without auth, causing silent failures on
+  servers that require a key.
+
+### Changed
+- `loadSettings()` moved from `compat.ts` to `config.ts`. `compat.ts` now
+  contains only business logic (no `fs` import).
+
 ## [0.1.4] - 2026-05-02
 
 ### Added
@@ -90,7 +116,8 @@ section is also used as the body of the Release notes by the
   `--` separator.
 - CI workflow (Node 20, 22) and npm publish workflow triggered by GitHub Release.
 
-[Unreleased]: https://github.com/mforce/claudely/compare/v0.1.4...HEAD
+[Unreleased]: https://github.com/mforce/claudely/compare/v0.1.5...HEAD
+[0.1.5]: https://github.com/mforce/claudely/compare/v0.1.4...v0.1.5
 [0.1.4]: https://github.com/mforce/claudely/compare/v0.1.3...v0.1.4
 [0.1.3]: https://github.com/mforce/claudely/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/mforce/claudely/compare/v0.1.1...v0.1.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claudely",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claudely",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "^7.2.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claudely",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Claude, locally. Launch Claude Code against a local LLM (LM Studio, Ollama, llama.cpp, or any Anthropic-compatible endpoint). Unaffiliated community helper.",
   "license": "MIT",
   "author": "mforce",


### PR DESCRIPTION
## Summary

Version bump to 0.1.5. CHANGELOG entry covers:

- `claudely setup` interactive wizard with persistent config
- llamacpp `auth_token` fix for Claude Max users (401 fix)
- Setup wizard connection test auth header fix
- `loadSettings` decoupled from compat.ts → config.ts

**Merge order:** merge #16 first, then this PR. The `release-on-version-bump` workflow should detect the `package.json` change and auto-create the v0.1.5 tag + GitHub Release, which triggers `publish.yml` to push to npm.

## Test plan

- [x] PR #16 merged first
- [x] CI green
- [x] After merge: `release-on-version-bump` creates v0.1.5 tag + Release
- [ ] `publish.yml` fires and publishes to npm