### PR TITLE
fix: empty token overrides provider default + hardcoded error message

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -163,18 +163,18 @@ async function main(): Promise<number> {
   }
 
   const baseUrl =
-    values["base-url"] ?? process.env.CLAUDELY_BASE_URL ?? config.baseUrl ?? provider.defaultBaseUrl();
-  const token = values.token ?? process.env.CLAUDELY_TOKEN ?? config.token ?? provider.defaultToken;
+    values["base-url"] ?? process.env.CLAUDELY_BASE_URL ?? (config.baseUrl || undefined) ?? provider.defaultBaseUrl();
+  const token = values.token ?? process.env.CLAUDELY_TOKEN ?? (config.token || undefined) ?? provider.defaultToken;
 
   if (!baseUrl) {
     console.error(
-      "claudely: provider 'custom' requires --base-url <url> (or $CLAUDELY_BASE_URL)",
+      `claudely: provider '${providerName}' requires --base-url <url> (or $CLAUDELY_BASE_URL, or run \`claudely setup\`)`,
     );
     return 2;
   }
   if (!token) {
     console.error(
-      "claudely: provider 'custom' requires --token <token> (or $CLAUDELY_TOKEN)",
+      `claudely: provider '${providerName}' requires --token <token> (or $CLAUDELY_TOKEN, or run \`claudely setup\`)`,
     );
     return 2;
   }

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -29,14 +29,22 @@ export async function runSetup(): Promise<number> {
 
   const provider = PROVIDERS[providerName];
 
+  const providerDefault = provider.defaultBaseUrl();
   const baseUrl = await input({
-    message: "Base URL",
-    default: existing.baseUrl ?? provider.defaultBaseUrl(),
+    message: existing.baseUrl && existing.baseUrl !== providerDefault
+      ? `Base URL (provider default: ${providerDefault})`
+      : "Base URL",
+    default: existing.baseUrl || providerDefault,
   });
 
+  const tokenDefault = provider.defaultToken;
   const token = await input({
-    message: "Auth token",
-    default: existing.token ?? provider.defaultToken,
+    message: tokenDefault
+      ? existing.token && existing.token !== tokenDefault
+        ? `Auth token (provider default: ${tokenDefault})`
+        : "Auth token"
+      : "Auth token (required)",
+    default: existing.token || tokenDefault,
   });
 
   let models: ModelEntry[] = [];
@@ -73,13 +81,14 @@ export async function runSetup(): Promise<number> {
     if (manual) model = manual;
   }
 
-  const config: ClaudelyConfig = { provider: providerName, baseUrl, token };
+  const config: ClaudelyConfig = { provider: providerName, baseUrl };
+  if (token) config.token = token;
   if (model) config.model = model;
 
   console.log("\nConfig to save:");
   console.log(`  provider:  ${config.provider}`);
   console.log(`  baseUrl:   ${config.baseUrl}`);
-  console.log(`  token:     ${config.token}`);
+  console.log(`  token:     ${config.token ?? "(provider default)"}`);
   if (config.model) console.log(`  model:     ${config.model}`);
   console.log();
 


### PR DESCRIPTION
## Summary

Three bugs fixed:

1. **Empty token in config blocks provider default** — `claudely setup` saved `token: ""` which `??` treated as defined, preventing fallthrough to the provider's default token (e.g. `"lmstudio"`). Now empty strings are skipped when saving, and cli.ts treats empty config values as undefined.

2. **Error message hardcodes 'custom'** — `"provider 'custom' requires --token"` fired for ALL providers when token was empty. Now shows the actual provider name and suggests `claudely setup`.

3. **Setup wizard doesn't show provider defaults** — When the saved value differs from the provider default, the prompt now shows both (e.g. `Auth token (provider default: lmstudio)`).

## Test plan

- [x] `npm test` — 87 pass
- [ ] `claudely setup` with lmstudio, clear token → saves without token field
- [ ] `claudely --new` after saving empty token → uses provider default, no error
- [ ] `claudely setup` re-run shows provider defaults in prompts