### PR TITLE
chore: bump to 0.1.6 (setup wizard UX fixes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,23 @@ section is also used as the body of the Release notes by the
 
 ## [Unreleased]
 
+## [0.1.6] - 2026-05-03
+
+### Fixed
+- Empty auth token in saved config no longer overrides the provider
+  default. Previously, clearing the token in `claudely setup` saved
+  `token: ""` which blocked fallthrough to the provider's built-in
+  default (e.g. `"lmstudio"`).
+- Error messages for missing base URL or token now show the actual
+  provider name instead of hardcoding `'custom'`, and suggest running
+  `claudely setup`.
+
+### Changed
+- `claudely setup` base URL step now offers a select menu (current /
+  provider default / custom) when a saved config already exists.
+- Auth token prompt simplified to plain text input with current value
+  as default.
+
 ## [0.1.5] - 2026-05-03
 
 ### Added
@@ -116,7 +133,8 @@ section is also used as the body of the Release notes by the
   `--` separator.
 - CI workflow (Node 20, 22) and npm publish workflow triggered by GitHub Release.
 
-[Unreleased]: https://github.com/mforce/claudely/compare/v0.1.5...HEAD
+[Unreleased]: https://github.com/mforce/claudely/compare/v0.1.6...HEAD
+[0.1.6]: https://github.com/mforce/claudely/compare/v0.1.5...v0.1.6
 [0.1.5]: https://github.com/mforce/claudely/compare/v0.1.4...v0.1.5
 [0.1.4]: https://github.com/mforce/claudely/compare/v0.1.3...v0.1.4
 [0.1.3]: https://github.com/mforce/claudely/compare/v0.1.2...v0.1.3

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claudely",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claudely",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "^7.2.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claudely",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Claude, locally. Launch Claude Code against a local LLM (LM Studio, Ollama, llama.cpp, or any Anthropic-compatible endpoint). Unaffiliated community helper.",
   "license": "MIT",
   "author": "mforce",


### PR DESCRIPTION
## Summary

Version bump to 0.1.6. Includes fixes from #20:
- Empty token no longer overrides provider default
- Error messages show actual provider name + suggest `claudely setup`
- Base URL step offers current/default/custom select menu
- Auth token prompt simplified to plain input

Tests the `release-on-version-bump` → `publish.yml` pipeline (requires `RELEASE_PAT` secret).

## Test plan

- [x] `npm test` — 88 pass
- [x] CI green
- [x] After merge: release workflow creates v0.1.6 tag + Release → publishes to npm