### PR TITLE
fix: drop auto-resume on bare claudely (Claude >=2.1 broke prompt-less --continue)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ section is also used as the body of the Release notes by the
 
 ## [Unreleased]
 
+### Fixed
+- Bare `claudely` (auto-resume) now always injects the configured provider
+  model via `--model`. Previously auto-resume spawned `claude --continue`
+  with no model, so claude fell back to the model in `~/.claude/settings.json`
+  (e.g. `opus[1m]`). Because that session often belonged to a different
+  endpoint (the shared `~/.claude/projects/` dir also holds Anthropic-API
+  sessions), the Anthropic model didn't exist on the local server, producing
+  "There's an issue with the selected model". Explicit resume flags
+  (`-c`/`-r`/`--session-id`/`--from-pr`) still skip model injection and keep
+  the saved session's model.
+
 ## [0.1.6] - 2026-05-03
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,16 +11,26 @@ section is also used as the body of the Release notes by the
 
 ## [Unreleased]
 
-### Fixed
-- Bare `claudely` (auto-resume) now always injects the configured provider
-  model via `--model`. Previously auto-resume spawned `claude --continue`
-  with no model, so claude fell back to the model in `~/.claude/settings.json`
-  (e.g. `opus[1m]`). Because that session often belonged to a different
-  endpoint (the shared `~/.claude/projects/` dir also holds Anthropic-API
-  sessions), the Anthropic model didn't exist on the local server, producing
-  "There's an issue with the selected model". Explicit resume flags
-  (`-c`/`-r`/`--session-id`/`--from-pr`) still skip model injection and keep
-  the saved session's model.
+### Removed
+- **Auto-resume on bare `claudely`.** Previously a bare invocation with a
+  saved session in `~/.claude/projects/` spawned `claude --continue` with no
+  prompt. Claude >=2.1 dropped prompt-less `--continue` (it now errors `No
+  conversation found to continue`), so auto-resume could no longer work.
+  Bare `claudely` now always starts a FRESH session; resume a conversation
+  explicitly with `claudely -c "<prompt>"` or `claudely -r`. The `--new`
+  flag and `CLAUDELY_NO_AUTO_RESUME` env var are gone as no longer
+  meaningful; `--new` is still accepted as a harmless no-op so old muscle
+  memory doesn't error.
+
+### Changed
+- **Explicit model pinning.** When starting fresh (or resuming with an
+  explicit `--model`), claudely always passes the configured provider model
+  via `--model`. `-c`/`-r`/`--session-id`/`--from-pr` without `--model` still
+  keep the saved session's model, so a locally-connecting claudely no longer
+  falls back to the Anthropic model in `~/.claude/settings.json` (e.g.
+  `opus[1m]`) that doesn't exist on a local server. Moved the model/current
+  decision into `resolveModelForSpawn()` so the fresh vs explicit-resume
+  behavior is unit-tested.
 
 ## [0.1.6] - 2026-05-03
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -30,8 +30,6 @@ import { renderVersion } from "./version.js";
 import {
   isResumeIntent,
   assembleClaudeArgv,
-  hasRecentSessionForCwd,
-  shouldAutoResume,
   resolveModelForSpawn,
 } from "./resume.js";
 
@@ -56,15 +54,16 @@ claudely options:
   -u, --base-url <url>    Override the provider's default base URL
   -t, --token <token>     Override the provider's default auth token
       --list              Print available models for the provider and exit
-      --new               Force a fresh session (skip auto-resume)
   -h, --help              Show this help
   -V, --version           Print claudely and claude versions, then exit
       setup               Configure provider, URL, token, and default model
 
-Bare \`claudely\` (no args, no --model) auto-resumes the most recent
-claude session for the current directory when one exists. Use --new to
-force a fresh session, or set CLAUDELY_NO_AUTO_RESUME=1 to disable
-auto-resume globally.
+Bare \`claudely\` (no args) starts a FRESH session with the configured
+provider model. To resume a previous conversation, pass a claude resume
+flag with a prompt (see examples), e.g. \`claudely -c "<prompt>"\`. The
+old auto-resume behavior (and the \`--new\` flag that toggled it) were
+removed, because Claude >=2.1 dropped prompt-less \`--continue\`; \`--new\`
+is still accepted as a no-op for backward compatibility.
 
 When you pass a claude resume flag (-c/--continue, -r/--resume,
 --session-id, --from-pr) claudely skips the model picker and does NOT
@@ -189,38 +188,13 @@ async function main(): Promise<number> {
     return 0;
   }
 
-  // Distinguish an EXPLICIT resume (user passed -c/-r/--session-id/--from-pr)
-  // from AUTO-resume (bare `claudely`, no args). Compute it from the args as
-  // they arrive, BEFORE auto-resume pushes --continue below — otherwise the
-  // synthetic --continue would mark a bare invocation as an explicit resume.
+  // Explicit resume flags (-c/-r/--session-id/--from-pr) mean the user chose
+  // to resume a specific conversation, so we keep that session's saved model:
+  // no --model injection and no picker. A bare `claudely` (no args) is a FRESH
+  // session — claude >=2.1 dropped prompt-less `--continue`, so auto-resuming
+  // a bare invocation would fail with "No conversation found to continue", and
+  // it could resume a stale Anthropic-API session from the shared ~/.claude dir.
   const explicitlyResuming = isResumeIntent(claudeArgs);
-
-  // Auto-resume on bare invocation: if the user typed `claudely` with no
-  // forwarded args and there's a saved session for this cwd, behave as if
-  // they had typed `claudely --continue`. --new and CLAUDELY_NO_AUTO_RESUME
-  // opt out.
-  const autoResume = shouldAutoResume({
-    ownValues: values,
-    claudeArgs,
-    hasRecentSession: hasRecentSessionForCwd(process.cwd()),
-    env: process.env,
-  });
-  if (autoResume) {
-    process.stderr.write("claudely: resuming previous session (use --new for a fresh one)\n");
-    claudeArgs.push("--continue");
-  }
-
-  // Resume vs. model selection are independent decisions:
-  //   - Resume controls whether the picker runs and whether --continue is added.
-  //   - Model selection controls what (if anything) goes into --model.
-  //
-  // Two kinds of resume, with opposite model intent:
-  //   - EXPLICIT resume: keep the saved session's model, never override or prompt.
-  //   - AUTO-resume: still apply the configured model. Otherwise `claude
-  //     --continue` falls back to the model in ~/.claude/settings.json (e.g.
-  //     opus[1m]) which doesn't exist on a local server and fails with "issue
-  //     with the selected model". claude supports --continue --model X.
-  const resuming = autoResume || explicitlyResuming;
 
   let { model, needsPicker } = resolveModelForSpawn({
     explicitModel: values.model,
@@ -230,8 +204,8 @@ async function main(): Promise<number> {
     explicitlyResuming,
   });
 
-  if (needsPicker && !resuming) {
-      const entries = await listForProvider(provider, baseUrl, token);
+  if (needsPicker && !explicitlyResuming) {
+    const entries = await listForProvider(provider, baseUrl, token);
       if (entries.length === 0) {
         console.error(
           `claudely: no models discovered for provider '${providerName}' at ${baseUrl}.`,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -32,6 +32,7 @@ import {
   assembleClaudeArgv,
   hasRecentSessionForCwd,
   shouldAutoResume,
+  resolveModelForSpawn,
 } from "./resume.js";
 
 const FLAG_SPEC: FlagSpec = {
@@ -188,6 +189,12 @@ async function main(): Promise<number> {
     return 0;
   }
 
+  // Distinguish an EXPLICIT resume (user passed -c/-r/--session-id/--from-pr)
+  // from AUTO-resume (bare `claudely`, no args). Compute it from the args as
+  // they arrive, BEFORE auto-resume pushes --continue below — otherwise the
+  // synthetic --continue would mark a bare invocation as an explicit resume.
+  const explicitlyResuming = isResumeIntent(claudeArgs);
+
   // Auto-resume on bare invocation: if the user typed `claudely` with no
   // forwarded args and there's a saved session for this cwd, behave as if
   // they had typed `claudely --continue`. --new and CLAUDELY_NO_AUTO_RESUME
@@ -206,20 +213,24 @@ async function main(): Promise<number> {
   // Resume vs. model selection are independent decisions:
   //   - Resume controls whether the picker runs and whether --continue is added.
   //   - Model selection controls what (if anything) goes into --model.
-  // On resume, an explicit CLI --model is still honored (claude supports
-  // --continue --model X to switch models on a resumed conversation), but
-  // env-derived model defaults are skipped — they're "default for fresh",
-  // not "intent to override the saved session".
-  const resuming = isResumeIntent(claudeArgs);
+  //
+  // Two kinds of resume, with opposite model intent:
+  //   - EXPLICIT resume: keep the saved session's model, never override or prompt.
+  //   - AUTO-resume: still apply the configured model. Otherwise `claude
+  //     --continue` falls back to the model in ~/.claude/settings.json (e.g.
+  //     opus[1m]) which doesn't exist on a local server and fails with "issue
+  //     with the selected model". claude supports --continue --model X.
+  const resuming = autoResume || explicitlyResuming;
 
-  let model: string | undefined = values.model;
-  if (!model && !resuming) {
-    model =
-      process.env.CLAUDELY_MODEL ??
-      config.model ??
-      (provider.modelEnvVar ? process.env[provider.modelEnvVar] : undefined);
+  let { model, needsPicker } = resolveModelForSpawn({
+    explicitModel: values.model,
+    env: process.env,
+    configModel: config.model,
+    providerModelEnvVar: provider.modelEnvVar,
+    explicitlyResuming,
+  });
 
-    if (!model) {
+  if (needsPicker && !resuming) {
       const entries = await listForProvider(provider, baseUrl, token);
       if (entries.length === 0) {
         console.error(
@@ -249,7 +260,6 @@ async function main(): Promise<number> {
           }));
         },
       });
-    }
   }
 
   // Build the env recipe to hand to claude.

--- a/src/resume.test.ts
+++ b/src/resume.test.ts
@@ -1,14 +1,8 @@
-import { test, beforeEach, afterEach } from "node:test";
+import { test } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
 import {
   isResumeIntent,
   assembleClaudeArgv,
-  encodeCwdForClaude,
-  hasRecentSessionForCwd,
-  shouldAutoResume,
   resolveModelForSpawn,
 } from "./resume.js";
 
@@ -125,110 +119,6 @@ test("assembleClaudeArgv: empty extras and claude args → just the model pair (
   );
 });
 
-test("encodeCwdForClaude mirrors claude's per-cwd directory naming", () => {
-  assert.equal(encodeCwdForClaude("/home/cesar/dev/claudely"), "-home-cesar-dev-claudely");
-  assert.equal(
-    encodeCwdForClaude("/home/cesar/dev/shelfydex--worktrees/feat-api-security"),
-    "-home-cesar-dev-shelfydex--worktrees-feat-api-security",
-  );
-});
-
-let fakeHome: string;
-
-beforeEach(() => {
-  fakeHome = mkdtempSync(join(tmpdir(), "claudely-home-"));
-});
-
-afterEach(() => {
-  rmSync(fakeHome, { recursive: true, force: true });
-});
-
-function seedSessionFile(cwd: string, sessionId: string) {
-  const dir = join(fakeHome, ".claude", "projects", encodeCwdForClaude(cwd));
-  mkdirSync(dir, { recursive: true });
-  writeFileSync(join(dir, `${sessionId}.jsonl`), '{"type":"summary"}\n');
-}
-
-test("hasRecentSessionForCwd: no projects dir at all → false", () => {
-  assert.equal(hasRecentSessionForCwd("/some/where", { home: fakeHome }), false);
-});
-
-test("hasRecentSessionForCwd: empty per-cwd dir (no .jsonl) → false", () => {
-  const cwd = "/home/u/proj";
-  mkdirSync(join(fakeHome, ".claude", "projects", encodeCwdForClaude(cwd)), {
-    recursive: true,
-  });
-  assert.equal(hasRecentSessionForCwd(cwd, { home: fakeHome }), false);
-});
-
-test("hasRecentSessionForCwd: per-cwd dir contains .jsonl → true", () => {
-  const cwd = "/home/u/proj";
-  seedSessionFile(cwd, "abc-session-id");
-  assert.equal(hasRecentSessionForCwd(cwd, { home: fakeHome }), true);
-});
-
-test("hasRecentSessionForCwd: only non-jsonl files (e.g. memory dir) → false", () => {
-  const cwd = "/home/u/proj";
-  const dir = join(fakeHome, ".claude", "projects", encodeCwdForClaude(cwd));
-  mkdirSync(join(dir, "memory"), { recursive: true });
-  writeFileSync(join(dir, "settings.json"), "{}");
-  assert.equal(hasRecentSessionForCwd(cwd, { home: fakeHome }), false);
-});
-
-test("hasRecentSessionForCwd: a different cwd's session does not leak", () => {
-  seedSessionFile("/home/u/other", "abc");
-  assert.equal(hasRecentSessionForCwd("/home/u/proj", { home: fakeHome }), false);
-});
-
-const baseInputs = {
-  ownValues: {},
-  claudeArgs: [] as string[],
-  hasRecentSession: true,
-  env: {} as NodeJS.ProcessEnv,
-};
-
-test("shouldAutoResume: bare invocation with a saved session → true", () => {
-  assert.equal(shouldAutoResume(baseInputs), true);
-});
-
-test("shouldAutoResume: no saved session → false", () => {
-  assert.equal(shouldAutoResume({ ...baseInputs, hasRecentSession: false }), false);
-});
-
-test("shouldAutoResume: --new opts out → false", () => {
-  assert.equal(shouldAutoResume({ ...baseInputs, ownValues: { new: true } }), false);
-});
-
-test("shouldAutoResume: --list path → false", () => {
-  assert.equal(shouldAutoResume({ ...baseInputs, ownValues: { list: true } }), false);
-});
-
-test("shouldAutoResume: --model present does NOT block auto-resume — model and resume are independent", () => {
-  assert.equal(shouldAutoResume({ ...baseInputs, ownValues: { model: "x" } }), true);
-});
-
-test("shouldAutoResume: any forwarded claudeArgs (positional or flag) → false", () => {
-  assert.equal(shouldAutoResume({ ...baseInputs, claudeArgs: ["--print", "hi"] }), false);
-  assert.equal(shouldAutoResume({ ...baseInputs, claudeArgs: ["explain X"] }), false);
-});
-
-test("shouldAutoResume: CLAUDELY_NO_AUTO_RESUME=1 opts out → false", () => {
-  assert.equal(
-    shouldAutoResume({ ...baseInputs, env: { CLAUDELY_NO_AUTO_RESUME: "1" } }),
-    false,
-  );
-});
-
-test("shouldAutoResume: CLAUDELY_NO_AUTO_RESUME=0/false/empty does NOT opt out", () => {
-  for (const v of ["0", "false", ""]) {
-    assert.equal(
-      shouldAutoResume({ ...baseInputs, env: { CLAUDELY_NO_AUTO_RESUME: v } }),
-      true,
-      `CLAUDELY_NO_AUTO_RESUME=${JSON.stringify(v)} should not opt out`,
-    );
-  }
-});
-
 test("resolveModelForSpawn: explicit CLI --model wins over everything, resume or not", () => {
   assert.deepEqual(
     resolveModelForSpawn({
@@ -251,18 +141,14 @@ test("resolveModelForSpawn: explicit CLI --model wins over everything, resume or
   );
 });
 
-test("resolveModelForSpawn: AUTO-resume (not explicit) still applies the configured model — regression for stale Anthropic sessions", () => {
-  // Bare `claudely` auto-resumes: the shared ~/.claude dir may hold a session
-  // from a different provider (Anthropic), so we MUST still pass the local
-  // config's model. claude --continue then uses it instead of falling back to
-  // the settings.json model (opus[1m]) which doesn't exist on the local server.
+test("resolveModelForSpawn: fresh run applies the configured model", () => {
   assert.deepEqual(
     resolveModelForSpawn({
       explicitModel: undefined,
       env: {},
       configModel: "deepseek-ai/DeepSeek-V4-Flash-0731",
       providerModelEnvVar: "LLAMACPP_MODEL",
-      explicitlyResuming: false, // auto-resume
+      explicitlyResuming: false,
     }),
     { model: "deepseek-ai/DeepSeek-V4-Flash-0731", needsPicker: false },
   );
@@ -325,18 +211,7 @@ test("resolveModelForSpawn: no model anywhere and not resuming → needs picker"
   );
 });
 
-test("resolveModelForSpawn: no model and resuming (auto or explicit) → no picker, no model (claude --continue already knows its session)", () => {
-  // Auto-resume with no configured model: skip picker, let claude --continue
-  // do its thing rather than interrupting to ask.
-  assert.deepEqual(
-    resolveModelForSpawn({
-      explicitModel: undefined,
-      env: {},
-      configModel: undefined,
-      explicitlyResuming: false,
-    }),
-    { model: undefined, needsPicker: true },
-  );
+test("resolveModelForSpawn: EXPLICIT resume with no model → no picker, no model (keeps saved session)", () => {
   assert.deepEqual(
     resolveModelForSpawn({
       explicitModel: undefined,

--- a/src/resume.test.ts
+++ b/src/resume.test.ts
@@ -9,6 +9,7 @@ import {
   encodeCwdForClaude,
   hasRecentSessionForCwd,
   shouldAutoResume,
+  resolveModelForSpawn,
 } from "./resume.js";
 
 test("isResumeIntent: empty args → false", () => {
@@ -226,4 +227,123 @@ test("shouldAutoResume: CLAUDELY_NO_AUTO_RESUME=0/false/empty does NOT opt out",
       `CLAUDELY_NO_AUTO_RESUME=${JSON.stringify(v)} should not opt out`,
     );
   }
+});
+
+test("resolveModelForSpawn: explicit CLI --model wins over everything, resume or not", () => {
+  assert.deepEqual(
+    resolveModelForSpawn({
+      explicitModel: "deepseek-ai/DeepSeek-V4-Flash-0731",
+      env: {},
+      configModel: "opus[1m]",
+      providerModelEnvVar: "LLAMACPP_MODEL",
+      explicitlyResuming: true,
+    }),
+    { model: "deepseek-ai/DeepSeek-V4-Flash-0731", needsPicker: false },
+  );
+  assert.deepEqual(
+    resolveModelForSpawn({
+      explicitModel: "deepseek-ai/DeepSeek-V4-Flash-0731",
+      env: {},
+      configModel: "opus[1m]",
+      explicitlyResuming: false,
+    }),
+    { model: "deepseek-ai/DeepSeek-V4-Flash-0731", needsPicker: false },
+  );
+});
+
+test("resolveModelForSpawn: AUTO-resume (not explicit) still applies the configured model — regression for stale Anthropic sessions", () => {
+  // Bare `claudely` auto-resumes: the shared ~/.claude dir may hold a session
+  // from a different provider (Anthropic), so we MUST still pass the local
+  // config's model. claude --continue then uses it instead of falling back to
+  // the settings.json model (opus[1m]) which doesn't exist on the local server.
+  assert.deepEqual(
+    resolveModelForSpawn({
+      explicitModel: undefined,
+      env: {},
+      configModel: "deepseek-ai/DeepSeek-V4-Flash-0731",
+      providerModelEnvVar: "LLAMACPP_MODEL",
+      explicitlyResuming: false, // auto-resume
+    }),
+    { model: "deepseek-ai/DeepSeek-V4-Flash-0731", needsPicker: false },
+  );
+});
+
+test("resolveModelForSpawn: EXPLICIT resume keeps the saved session's model (no override, no picker)", () => {
+  assert.deepEqual(
+    resolveModelForSpawn({
+      explicitModel: undefined,
+      env: {},
+      configModel: "deepseek-ai/DeepSeek-V4-Flash-0731",
+      providerModelEnvVar: "LLAMACPP_MODEL",
+      explicitlyResuming: true, // user passed -c / --session-id / etc.
+    }),
+    { model: undefined, needsPicker: false },
+  );
+});
+
+test("resolveModelForSpawn: fresh run falls back to CLAUDELY_MODEL then config then provider env", () => {
+  assert.deepEqual(
+    resolveModelForSpawn({
+      explicitModel: undefined,
+      env: { CLAUDELY_MODEL: "from-env" },
+      configModel: "config-model",
+      explicitlyResuming: false,
+    }),
+    { model: "from-env", needsPicker: false },
+  );
+  assert.deepEqual(
+    resolveModelForSpawn({
+      explicitModel: undefined,
+      env: {},
+      configModel: "config-model",
+      explicitlyResuming: false,
+    }),
+    { model: "config-model", needsPicker: false },
+  );
+  assert.deepEqual(
+    resolveModelForSpawn({
+      explicitModel: undefined,
+      env: { LLAMACPP_MODEL: "provider-env-model" },
+      configModel: undefined,
+      providerModelEnvVar: "LLAMACPP_MODEL",
+      explicitlyResuming: false,
+    }),
+    { model: "provider-env-model", needsPicker: false },
+  );
+});
+
+test("resolveModelForSpawn: no model anywhere and not resuming → needs picker", () => {
+  assert.deepEqual(
+    resolveModelForSpawn({
+      explicitModel: undefined,
+      env: {},
+      configModel: undefined,
+      providerModelEnvVar: "LLAMACPP_MODEL",
+      explicitlyResuming: false,
+    }),
+    { model: undefined, needsPicker: true },
+  );
+});
+
+test("resolveModelForSpawn: no model and resuming (auto or explicit) → no picker, no model (claude --continue already knows its session)", () => {
+  // Auto-resume with no configured model: skip picker, let claude --continue
+  // do its thing rather than interrupting to ask.
+  assert.deepEqual(
+    resolveModelForSpawn({
+      explicitModel: undefined,
+      env: {},
+      configModel: undefined,
+      explicitlyResuming: false,
+    }),
+    { model: undefined, needsPicker: true },
+  );
+  assert.deepEqual(
+    resolveModelForSpawn({
+      explicitModel: undefined,
+      env: {},
+      configModel: undefined,
+      explicitlyResuming: true,
+    }),
+    { model: undefined, needsPicker: false },
+  );
 });

--- a/src/resume.ts
+++ b/src/resume.ts
@@ -76,6 +76,49 @@ export interface AutoResumeInputs {
   env: NodeJS.ProcessEnv;
 }
 
+export interface ResolveModelForSpawnInputs {
+  // value of the claudely --model flag (undefined if not passed).
+  explicitModel?: string;
+  env: NodeJS.ProcessEnv;
+  // configured default model from ~/.config/claudely/config.json.
+  configModel?: string;
+  // provider-specific model env var name (e.g. OLLAMA_MODEL).
+  providerModelEnvVar?: string;
+  // true when the user passed an explicit resume flag (-c/-r/--session-id/--from-pr),
+  // as opposed to claudely auto-resuming a bare invocation.
+  explicitlyResuming: boolean;
+}
+
+export interface ModelResolution {
+  model: string | undefined;
+  needsPicker: boolean;
+}
+
+// Decide which --model (if any) to hand to claude, and whether the interactive
+// picker must run. Resume intent affects both:
+//   - Explicit CLI --model always wins, resume or not (claude supports
+//     --continue --model X to switch models while resuming).
+//   - Explicit resume (user chose to resume a specific session) keeps that
+//     session's saved model: no override, no picker.
+//   - Fresh OR auto-resume falls back to the configured model for this
+//     provider. On AUTO-resume this matters: the "session" may belong to a
+//     DIFFERENT provider (the shared ~/.claude dir holds Anthropic-API
+//     sessions), and a bare `claude --continue` would otherwise fall back to
+//     the model in ~/.claude/settings.json (e.g. opus[1m]) which doesn't exist
+//     on a local server and fails with "issue with the selected model".
+export function resolveModelForSpawn(inputs: ResolveModelForSpawnInputs): ModelResolution {
+  if (inputs.explicitModel) return { model: inputs.explicitModel, needsPicker: false };
+  if (inputs.explicitlyResuming) return { model: undefined, needsPicker: false };
+
+  const fromEnv =
+    inputs.env.CLAUDELY_MODEL ??
+    inputs.configModel ??
+    (inputs.providerModelEnvVar ? inputs.env[inputs.providerModelEnvVar] : undefined);
+  if (fromEnv) return { model: fromEnv, needsPicker: false };
+
+  return { model: undefined, needsPicker: true };
+}
+
 export function shouldAutoResume(inputs: AutoResumeInputs): boolean {
   if (!inputs.hasRecentSession) return false;
   if (inputs.ownValues.new) return false;

--- a/src/resume.ts
+++ b/src/resume.ts
@@ -10,10 +10,6 @@
 //   --session-id <uuid>             use a specific session id
 //   --from-pr [value]               resume the session linked to a PR
 
-import { readdirSync } from "node:fs";
-import { homedir } from "node:os";
-import { join } from "node:path";
-
 const RESUME_BOOLS = new Set(["-c", "--continue"]);
 
 // Flags that are themselves resume intent regardless of their value form
@@ -42,40 +38,6 @@ export function assembleClaudeArgv(opts: AssembleArgs): string[] {
   return [...head, ...opts.extraArgs, ...opts.claudeArgs];
 }
 
-// claude stores per-cwd sessions under ~/.claude/projects/<encoded-cwd>/.
-// The encoding replaces path separators with `-` (e.g. /home/u/x → -home-u-x).
-// We mirror that to detect "is there a previous session here?" without spawning.
-export function encodeCwdForClaude(cwd: string): string {
-  return cwd.replace(/\//g, "-");
-}
-
-export interface SessionLookupOpts {
-  // Override for tests; defaults to os.homedir().
-  home?: string;
-}
-
-export function hasRecentSessionForCwd(cwd: string, opts: SessionLookupOpts = {}): boolean {
-  const root = opts.home ?? homedir();
-  const dir = join(root, ".claude", "projects", encodeCwdForClaude(cwd));
-  try {
-    const entries = readdirSync(dir, { withFileTypes: true });
-    return entries.some((e) => e.isFile() && e.name.endsWith(".jsonl"));
-  } catch {
-    return false;
-  }
-}
-
-export interface AutoResumeInputs {
-  ownValues: {
-    model?: string | undefined;
-    list?: boolean | undefined;
-    new?: boolean | undefined;
-  };
-  claudeArgs: readonly string[];
-  hasRecentSession: boolean;
-  env: NodeJS.ProcessEnv;
-}
-
 export interface ResolveModelForSpawnInputs {
   // value of the claudely --model flag (undefined if not passed).
   explicitModel?: string;
@@ -84,8 +46,8 @@ export interface ResolveModelForSpawnInputs {
   configModel?: string;
   // provider-specific model env var name (e.g. OLLAMA_MODEL).
   providerModelEnvVar?: string;
-  // true when the user passed an explicit resume flag (-c/-r/--session-id/--from-pr),
-  // as opposed to claudely auto-resuming a bare invocation.
+  // true when the user passed a resume flag (-c/-r/--session-id/--from-pr) and
+  // therefore wants to keep the saved session's model.
   explicitlyResuming: boolean;
 }
 
@@ -95,17 +57,13 @@ export interface ModelResolution {
 }
 
 // Decide which --model (if any) to hand to claude, and whether the interactive
-// picker must run. Resume intent affects both:
+// picker must run. Explicit resume intent affects both:
 //   - Explicit CLI --model always wins, resume or not (claude supports
 //     --continue --model X to switch models while resuming).
 //   - Explicit resume (user chose to resume a specific session) keeps that
 //     session's saved model: no override, no picker.
-//   - Fresh OR auto-resume falls back to the configured model for this
-//     provider. On AUTO-resume this matters: the "session" may belong to a
-//     DIFFERENT provider (the shared ~/.claude dir holds Anthropic-API
-//     sessions), and a bare `claude --continue` would otherwise fall back to
-//     the model in ~/.claude/settings.json (e.g. opus[1m]) which doesn't exist
-//     on a local server and fails with "issue with the selected model".
+//   - Otherwise (fresh run) fall back to the configured model for this
+//     provider; if none is configured, the picker must run.
 export function resolveModelForSpawn(inputs: ResolveModelForSpawnInputs): ModelResolution {
   if (inputs.explicitModel) return { model: inputs.explicitModel, needsPicker: false };
   if (inputs.explicitlyResuming) return { model: undefined, needsPicker: false };
@@ -117,15 +75,4 @@ export function resolveModelForSpawn(inputs: ResolveModelForSpawnInputs): ModelR
   if (fromEnv) return { model: fromEnv, needsPicker: false };
 
   return { model: undefined, needsPicker: true };
-}
-
-export function shouldAutoResume(inputs: AutoResumeInputs): boolean {
-  if (!inputs.hasRecentSession) return false;
-  if (inputs.ownValues.new) return false;
-  if (inputs.ownValues.list) return false;
-  if (inputs.claudeArgs.length > 0) return false;
-  if (isResumeIntent(inputs.claudeArgs)) return false;
-  const optOut = inputs.env.CLAUDELY_NO_AUTO_RESUME;
-  if (optOut && optOut !== "0" && optOut !== "" && optOut !== "false") return false;
-  return true;
 }


### PR DESCRIPTION
## Summary

Fixes #26. There were **two** breakages caused by Claude 2.1.187, and fixing just the model wasn't enough.

### Root cause 1 — wrong model on resume
Auto-resume spawned `claude --continue` without `--model`, so claude fell back to the model in `~/.claude/settings.json` (`opus[1m]`), which doesn't exist on a local server → "There's an issue with the selected model".

### Root cause 2 — Claude 2.1 dropped prompt-less `--continue`
The bigger problem: Claude >=2.1 now rejects a bare `claude --continue` (no prompt) with **"No conversation found to continue"**. claudely's auto-resume (added in 0.1.4) spawned exactly that, so bare `claudely` simply couldn't resume anymore — model fix or not.

### Fix (this PR)
- **Remove auto-resume.** Bare `claudely` now always starts a **fresh** session with the configured provider model.
- **Resume explicitly:** `claudely -c "<prompt>"` / `-r` / `--session-id` / `--from-pr` still work and keep the saved session's model.
- **`--new`** is kept as a **no-op** (backward compat) so old `claudely --new` doesn't error as an unknown claude flag.
- Fresh runs always inject `--model <configured>`, so the local model is used, never the settings.json fallback.

## Changes
- `src/resume.ts`: remove auto-resume helpers (`shouldAutoResume`, `hasRecentSessionForCwd`, `encodeCwdForClaude`); keep pure `resolveModelForSpawn()` for fresh vs explicit-resume.
- `src/cli.ts`: drop the auto-resume `--continue` push; `--new` becomes a recognized no-op; pin local model on fresh; explicit resume keeps saved model.
- `src/resume.test.ts`: drop auto-resume tests; add fresh/explicit-resume coverage.
- `CHANGELOG.md`: entry under `[Unreleased]`.

## Verification
- `npm test`: 80/80 pass.
- E2E with fake `claude` shim + a saved session present:
  - Bare `claudely` → `--model deepseek-ai/DeepSeek-V4-Flash-0731` (no `--continue`, fresh) ✅
  - `claudely --continue <prompt>` → `--continue <prompt>` (no model injected, keeps saved) ✅
  - `claudely --new` → `--model <local>` (`--new` absorbed, not forwarded) ✅
- Fresh run against the real vllm server: replies correctly.
